### PR TITLE
Clean matlab comments

### DIFF
--- a/matlabCode/createBIDS_FullExample_events_tsv.m
+++ b/matlabCode/createBIDS_FullExample_events_tsv.m
@@ -1,11 +1,12 @@
 %% Template Matlab script to create an BIDS compatible sub-01_ses-01_task-FullExample-01_events.tsv file
 % This example lists all required and optional fields.
-% When adding additional metadata please use camelcase
+% When adding additional metadata please use CamelCase
 % 
-%
 % anushkab, 2018
+% modified RG 201809
+
 %%
-clear all
+clear
 root_dir = '../';
 project_label = 'templates';
 sub_id = '01';
@@ -15,7 +16,6 @@ task_id = 'FullExample';
 acquisition = 'func';
 run_id='01';
 
-
 events_tsv_name = fullfile(root_dir,project_label,...
   ['sub-' sub_id],...
               ['ses-' ses_id],acquisition,...
@@ -24,25 +24,38 @@ events_tsv_name = fullfile(root_dir,project_label,...
               '_task-' task_id ...
               '_run-' run_id '_events.tsv']);
               
-%% make a _events table and save 
-%% CONTAINS a set of REQUIRED and OPTIONAL columns
-onset = [0]'; %REQUIRED Onset (in seconds) of the event  measured from the beginning of the acquisition of the first volume in the corresponding task imaging data file.  If any acquired scans have been discarded before forming the imaging data file, ensure that a time of 0 corresponds to the first image stored. In other words negative numbers in “onset” are allowed.
+%% make an event table and save 
 
-% REQUIRED. Duration of the event (measured  from onset) in seconds.  Must always be either zero or positive. A "duration" value of zero implies that the delta function or event is so short as to be effectively modeled as an impulse.
+%% CONTAINS a set of REQUIRED and OPTIONAL columns
+%REQUIRED Onset (in seconds) of the event  measured from the beginning of 
+% the acquisition of the first volume in the corresponding task imaging data file.  
+% If any acquired scans have been discarded before forming the imaging data file, 
+% ensure that a time of 0 corresponds to the first image stored. In other words 
+% negative numbers in onset are allowed.
+onset = [0]'; 
+
+%REQUIRED. Duration of the event (measured  from onset) in seconds.  
+% Must always be either zero or positive. A "duration" value of zero implies 
+% that the delta function or event is so short as to be effectively modeled as an impulse.
 duration = [0]'; 
 
-%OPTIONAL Primary categorisation of each trial to identify them as instances of the experimental conditions
+%OPTIONAL Primary categorisation of each trial to identify them as instances 
+% of the experimental conditions
 trial_type={' '};
 
-%OPTIONAL. Response time measured in seconds. A negative response time can be used to represent preemptive responses and “n/a” denotes a missed response.
+%OPTIONAL. Response time measured in seconds. A negative response time can be 
+% used to represent preemptive responses and n/a denotes a missed response.
 response_time=[0]';
 
-%OPTIONAL Represents the location of the stimulus file (image, video, sound etc.) presented at the given onset time
+%OPTIONAL Represents the location of the stimulus file (image, video, sound etc.) 
+% presented at the given onset time
 stim_file={' '}; 
 
 %OPTIONAL Hierarchical Event Descriptor (HED) Tag.
 HED= {' '}; 
 
+
+%% Save table
 t = table(onset,duration,trial_type,response_time,stim_file,HED);
 
 writetable(t,events_tsv_name,'FileType','text','Delimiter','\t');

--- a/matlabCode/createBIDS_anat_Full_T1w_json.m
+++ b/matlabCode/createBIDS_anat_Full_T1w_json.m
@@ -47,29 +47,29 @@ anat_json_name = fullfile(root_dir,project_label,...
 anat_json.Manufacturer=' ';
 
 %RECOMMENDED Manufacturer`s model name of the equipment that produced the 
-% composite instances. Corresponds to DICOM Tag 0008, 1090 Manufacturers Model Name.
+% composite instances. Corresponds to DICOM Tag 0008, 1090 "Manufacturers Model Name".
 anant_json.ManufacturersModelName=' ';
 
 %RECOMMENDED Nominal field strength of MR magnet in Tesla. Corresponds to 
-% DICOM Tag 0018,0087 Magnetic Field Strength.
+% DICOM Tag 0018,0087 "Magnetic Field Strength".
 anat_json.MagneticFieldStrength=' ';
 
 %RECOMMENDED The serial number of the equipment that produced the composite 
-% instances. Corresponds to DICOM Tag 0018, 1000 DeviceSerialNumber. 
+% instances. Corresponds to DICOM Tag 0018, 1000 "DeviceSerialNumber". 
 anat_json.DeviceSerialNumber=' ';
 
 %RECOMMENDED Institution defined name of the machine that produced the composite 
-% instances. Corresponds to DICOM Tag 0008, 1010 Station Name
+% instances. Corresponds to DICOM Tag 0008, 1010 "Station Name"
 anat_json.StationName= ' '; 
 
 %RECOMMENDED Manufacturer's designation of software version of the equipment 
 % that produced the composite instances. Corresponds to 
-% DICOM Tag 0018, 1020 Software Versions.
+% DICOM Tag 0018, 1020 "Software Versions".
 anat_json.SoftwareVersions= ' ';
 
 %RECOMMENDED (Deprecated) Manufacturer's designation of the software of the 
 % device that created this Hardcopy Image (the printer). Corresponds to 
-% DICOM Tag 0018, 101A Hardcopy Device Software Version.
+% DICOM Tag 0018, 101 "Hardcopy Device Software Version".
 anat_json.HardcopyDeviceSoftwareVersion=' ';
 
 %RECOMMENDED Information describing the receiver coil
@@ -82,7 +82,7 @@ anat_json.ReceiveCoilActiveElements=' ';
 anat_json.GradientSetType=' ';
 
 %RECOMMENDED This is a relevant field if a non-standard transmit coil is used. 
-% Corresponds to DICOM Tag 0018, 9049 MR Transmit Coil Sequence.
+% Corresponds to DICOM Tag 0018, 9049 "MR Transmit Coil Sequence".
 anat_json.MRTransmitCoilSequence=' ';
 
 %RECOMMENDED A method for reducing the number of independent channels by 
@@ -106,19 +106,19 @@ anat_json.CoilCombinationMethod=' ';
 anat_json.PulseSequenceType=' ';
 
 %RECOMMENDED Description of the type of data acquired. Corresponds to 
-% DICOM Tag 0018, 0020 Sequence Sequence.
+% DICOM Tag 0018, 0020 "Sequence Sequence".
 anat_json.ScanningSequence=' ';
 
 %RECOMMENDED Variant of the ScanningSequence. Corresponds to 
-% DICOM Tag 0018, 0021 Sequence Variant.
+% DICOM Tag 0018, 0021 "Sequence Variant".
 anat_json.SequenceVariant=' ';
 
 %RECOMMENDED Parameters of ScanningSequence. Corresponds to 
-% DICOM Tag 0018, 0022 Scan Options.
+% DICOM Tag 0018, 0022 "Scan Options".
 anat_json.ScanOptions=' ';
 
 %RECOMMENDED Manufacturer's designation of the sequence name. Corresponds 
-% to DICOM Tag 0018, 0024 Sequence Name.
+% to DICOM Tag 0018, 0024 "Sequence Name".
 anat_json.SequenceName=' ';
 
 %RECOMMENDED Information beyond pulse sequence type that identifies the 
@@ -143,15 +143,15 @@ anat_json.NumberShots=' ';
 anat_json.ParallelReductionFactorInPlane=' ';
 
 %RECOMMENDED The type of parallel imaging used (e.g. GRAPPA, SENSE). 
-% Corresponds to DICOM Tag 0018, 9078 Parallel Acquisition Technique. 
+% Corresponds to DICOM Tag 0018, 9078 "Parallel Acquisition Technique". 
 anat_json.ParallelAcquisitionTechnique=' ';
 
 %RECOMMENDED The fraction of partial Fourier information collected. 
-% Corresponds to DICOM Tag 0018, 9081 Partial Fourier.
+% Corresponds to DICOM Tag 0018, 9081 "Partial Fourier".
 anat_json.PartialFourier=' ';
 
 %RECOMMENDED The direction where only partial Fourier information was collected. 
-% Corresponds to DICOM Tag 0018, 9036 Partial Fourier Direction
+% Corresponds to DICOM Tag 0018, 9036 "Partial Fourier Direction"
 anat_json.PartialFourierDirection=' ';
 
 %RECOMMENDED defined as the displacement of the water signal with respect to 
@@ -167,7 +167,7 @@ anat_json.EchoTrainLength=' ';
 
 %REQUIRED if corresponding fieldmap data is present or the data comes from 
 % a multi echo sequence. The echo time (TE) for the acquisition, specified in seconds. 
-%Corresponds to DICOM Tag 0018, 0081 Echo Time
+%Corresponds to DICOM Tag 0018, 0081 "Echo Time"
 anat_json.EchoTime=' ';
 
 
@@ -177,7 +177,7 @@ anat_json.EchoTime=' ';
 % of excitation pulse to detect the amount of longitudinal magnetization
 anat_json.InversionTime=' ';
 
-%RECOMMENDED  Possible values: i, j, k, i-, j-, k- (the axis of the NIfTI data 
+%RECOMMENDED  Possible values: "i", "j", "k", "i-", "j-", "k-" (the axis of the NIfTI data 
 % along which slices were acquired, and the direction in which SliceTiming 
 % is  defined with respect to). "i", "j", "k" identifiers correspond to the 
 % first, second and third axis of the data in the NIfTI file. When present 
@@ -195,7 +195,7 @@ anat_json.DwellTime=' ';
 %% RF & Contrast metadata field
 
 %RECOMMENDED Flip angle for the acquisition, specified in degrees. 
-% Corresponds to: DICOM Tag 0018, 1314 Flip Angle.
+% Corresponds to: DICOM Tag 0018, 1314 "Flip Angle".
 anat_json.FlipAngle=' ';
 
 
@@ -219,17 +219,17 @@ anat_json.AnatomicalLandmarkCoordinates=' ';
 
 %RECOMMENDED The name of the institution in charge of the equipment that 
 % produced the composite instances. Corresponds to 
-% DICOM Tag 0008, 0080 InstitutionName.
+% DICOM Tag 0008, 0080 "InstitutionName".
 anat_json.InstitutionName=' ';
 
 %RECOMMENDED The address of the institution in charge of the equipment that 
 % produced the composite instances. Corresponds to 
-% DICOM Tag 0008, 0081 InstitutionAddress
+% DICOM Tag 0008, 0081 "InstitutionAddress"
 anat_json.InstitutionAddress=' ';
 
 %RECOMMENDED The department in the  institution in charge of the equipment 
 % that produced the composite instances. Corresponds to 
-% DICOM Tag 0008, 1040 Institutional Department Name.
+% DICOM Tag 0008, 1040 "Institutional Department Name".
 anat_json.InstitutionalDepartmentName=' ';
 
 

--- a/matlabCode/createBIDS_anat_Full_T1w_json.m
+++ b/matlabCode/createBIDS_anat_Full_T1w_json.m
@@ -1,9 +1,10 @@
 %% Template Matlab script to create an BIDS compatible sub-01_ses-01_acq-FullExample_run-01_T1w.json file
 % This example lists all required  RECOMMENDED and optional fields.
-% When adding additional metadata please use camelcase
+% When adding additional metadata please use CamelCase 
 % 
-%
 % anushkab, 2018
+% modified RG 201809
+
 %%
 clear all
 root_dir = '../';
@@ -11,17 +12,20 @@ project_label = 'templates';
 sub_id = '01';
 ses_id = '01';
 
-%The OPTIONAL “acq-<label>” key/value pair corresponds to a custom label the user MAY use to distinguish a different set of parameters used for acquiring the same modality. 
+%The OPTIONAL acq-<label> key/value pair corresponds to a custom label 
+% the user MAY use to distinguish a different set of parameters used for 
+% acquiring the same modality.  
 
 acq_id = 'FullExample'; 
 
 acquisition = 'anat';
 
-%OPTIONAL “ce-<label>” key/value can be used to distinguish sequences using different contrast enhanced images
-%OPTIONAL “rec-<label>” key/value can be used to distinguish different reconstruction algorithms 
+%OPTIONAL ce-<label> key/value can be used to distinguish sequences 
+% using different contrast enhanced images
+%OPTIONAL rec-<label> key/value can be used to distinguish different 
+% reconstruction algorithms 
 
 run_id='01';
-
 
 anat_json_name = fullfile(root_dir,project_label,...
   ['sub-' sub_id],...==
@@ -31,121 +35,127 @@ anat_json_name = fullfile(root_dir,project_label,...
               '_acq-' acq_id ...
               '_run-' run_id '_T1w.json']);
 
+%%
 % Assign the fields in the Matlab structure that can be saved as a json.
-%
-
-%% all REQUIRED /RECOMMENDED /OPTIONAL metadata fields for Magnetic Resonance Imaging data
+% all REQUIRED /RECOMMENDED /OPTIONAL metadata fields for Magnetic Resonance Imaging data
 
 
 
-
-
-%Scanner Hardware metadata fields
+%% Scanner Hardware metadata fields
 
 %RECOMMENDED Manufacturer of the equipment that produced the composite instances.
 anat_json.Manufacturer=' ';
 
-%RECOMMENDED Manufacturer`s model name of the equipment that produced the composite instances. Corresponds to DICOM Tag 0008, 1090 “Manufacturers Model Name”.
+%RECOMMENDED Manufacturer`s model name of the equipment that produced the 
+% composite instances. Corresponds to DICOM Tag 0008, 1090 Manufacturers Model Name.
 anant_json.ManufacturersModelName=' ';
 
-%RECOMMENDED Nominal field strength of MR magnet in Tesla. Corresponds to DICOM Tag 0018,0087 “Magnetic Field Strength” .
+%RECOMMENDED Nominal field strength of MR magnet in Tesla. Corresponds to 
+% DICOM Tag 0018,0087 Magnetic Field Strength.
 anat_json.MagneticFieldStrength=' ';
 
-
-%RECOMMENDED The serial number of the equipment that produced the composite instances. Corresponds to DICOM Tag 0018, 1000 ”DeviceSerialNumber”. 
+%RECOMMENDED The serial number of the equipment that produced the composite 
+% instances. Corresponds to DICOM Tag 0018, 1000 DeviceSerialNumber. 
 anat_json.DeviceSerialNumber=' ';
 
-%RECOMMENDED Institution defined name of the machine that produced the composite instances. Corresponds to DICOM Tag 0008, 1010 “Station Name”
+%RECOMMENDED Institution defined name of the machine that produced the composite 
+% instances. Corresponds to DICOM Tag 0008, 1010 Station Name
 anat_json.StationName= ' '; 
 
-%RECOMMENDED Manufacturer’s designation of software version of the equipment that produced the composite instances. Corresponds to DICOM Tag 0018, 1020 “Software Versions”.
+%RECOMMENDED Manufacturer's designation of software version of the equipment 
+% that produced the composite instances. Corresponds to 
+% DICOM Tag 0018, 1020 Software Versions.
 anat_json.SoftwareVersions= ' ';
 
-%RECOMMENDED (Deprecated) Manufacturer’s designation of the software of the device that created this Hardcopy Image (the printer). Corresponds to DICOM Tag 0018, 101A “Hardcopy Device Software Version”
+%RECOMMENDED (Deprecated) Manufacturer's designation of the software of the 
+% device that created this Hardcopy Image (the printer). Corresponds to 
+% DICOM Tag 0018, 101A Hardcopy Device Software Version.
 anat_json.HardcopyDeviceSoftwareVersion=' ';
 
-%RECOMMENDED  Information describing the receiver coil
+%RECOMMENDED Information describing the receiver coil
 anat_json.ReceiveCoilName= ' ' ;
 
 %RECOMMENDED Information describing the active/selected elements of the receiver coil. 
 anat_json.ReceiveCoilActiveElements=' ';
 
-
 %RECOMMENDED the specifications of the actual gradient coil from the scanner model
-
 anat_json.GradientSetType=' ';
 
-
-%RECOMMENDED This is a relevant field if a non-standard transmit coil is used. Corresponds to DICOM Tag 0018, 9049 “MR Transmit Coil Sequence”.
+%RECOMMENDED This is a relevant field if a non-standard transmit coil is used. 
+% Corresponds to DICOM Tag 0018, 9049 MR Transmit Coil Sequence.
 anat_json.MRTransmitCoilSequence=' ';
 
-%RECOMMENDED A method for reducing the number of independent channels by combining in analog the signals from multiple coil elements. There are typically different default modes when using un-accelerated or accelerated (e.g. GRAPPA, SENSE) imaging
+%RECOMMENDED A method for reducing the number of independent channels by 
+% combining in analog the signals from multiple coil elements. There are 
+% typically different default modes when using un-accelerated or accelerated 
+% (e.g. GRAPPA, SENSE) imaging
 anat_json.MatrixCoilMode=' ';
 
-%RECOMMENDED Almost all fMRI studies using phased-array coils use root-sum-of-squares (rSOS) combination, but other methods exist. The image reconstruction is changed by the coil combination method (as for the matrix coil mode above), so anything non-standard should be reported.
+%RECOMMENDED Almost all fMRI studies using phased-array coils use 
+% root-sum-of-squares (rSOS) combination, but other methods exist. 
+% The image reconstruction is changed by the coil combination method 
+% (as for the matrix coil mode above), so anything non-standard should be reported.
 anat_json.CoilCombinationMethod=' ';
 
 
 
-%Sequence Specifics metadata fields
+%% Sequence Specifics metadata fields
 
-%RECOMMENDED A general description of the pulse sequence used for the scan (i.e. MPRAGE, Gradient Echo EPI, Spin Echo EPI, Multiband gradient echo EPI).
+%RECOMMENDED A general description of the pulse sequence used for the scan 
+% (i.e. MPRAGE, Gradient Echo EPI, Spin Echo EPI, Multiband gradient echo EPI).
 anat_json.PulseSequenceType=' ';
 
-%RECOMMENDED Description of the type of data acquired. Corresponds to DICOM Tag 0018, 0020 “Sequence Sequence”.
+%RECOMMENDED Description of the type of data acquired. Corresponds to 
+% DICOM Tag 0018, 0020 Sequence Sequence.
 anat_json.ScanningSequence=' ';
 
-%RECOMMENDED Variant of the ScanningSequence. Corresponds to DICOM Tag 0018, 0021 “Sequence Variant”.
+%RECOMMENDED Variant of the ScanningSequence. Corresponds to 
+% DICOM Tag 0018, 0021 Sequence Variant.
 anat_json.SequenceVariant=' ';
 
-%RECOMMENDED Parameters of ScanningSequence. Corresponds to DICOM Tag 0018, 0022 “Scan Options”.
+%RECOMMENDED Parameters of ScanningSequence. Corresponds to 
+% DICOM Tag 0018, 0022 Scan Options.
 anat_json.ScanOptions=' ';
 
-%RECOMMENDED Manufacturer’s designation of the sequence name. Corresponds to DICOM Tag 0018, 0024 “Sequence Name”.
+%RECOMMENDED Manufacturer's designation of the sequence name. Corresponds 
+% to DICOM Tag 0018, 0024 Sequence Name.
 anat_json.SequenceName=' ';
 
-
-%RECOMMENDED Information beyond pulse sequence type that identifies the specific pulse sequence used
+%RECOMMENDED Information beyond pulse sequence type that identifies the 
+% specific pulse sequence used
 anat_json.PulseSequenceDetails=' ';
 
-%RECOMMENDED Boolean stating if the image saved  has been corrected for gradient nonlinearities by the scanner sequence. 
+%RECOMMENDED Boolean stating if the image saved  has been corrected for 
+% gradient nonlinearities by the scanner sequence. 
 anat_json.NonlinearGradientCorrection=' ';
 
 
 
-%In-Plane Spatial Encoding metadata fields
+%% In-Plane Spatial Encoding metadata fields
 
-%RECOMMENDED The number of RF excitations need to reconstruct a slice or volume. Please mind that  this is not the same as Echo Train Length which denotes the number of lines of k-space collected after an excitation. 
+%RECOMMENDED The number of RF excitations need to reconstruct a slice or volume. 
+% Please mind that  this is not the same as Echo Train Length which denotes 
+% the number of lines of k-space collected after an excitation. 
 anat_json.NumberShots=' ';
 
-%RECOMMENDED The parallel imaging (e.g, GRAPPA) factor. Use the denominator of the fraction of k-space encoded for each slice.
+%RECOMMENDED The parallel imaging (e.g, GRAPPA) factor. Use the denominator 
+% of the fraction of k-space encoded for each slice.
 anat_json.ParallelReductionFactorInPlane=' ';
 
-%RECOMMENDED The type of parallel imaging used (e.g. GRAPPA, SENSE). Corresponds to DICOM Tag 0018, 9078 “Parallel Acquisition Technique”. 
+%RECOMMENDED The type of parallel imaging used (e.g. GRAPPA, SENSE). 
+% Corresponds to DICOM Tag 0018, 9078 Parallel Acquisition Technique. 
 anat_json.ParallelAcquisitionTechnique=' ';
 
-%RECOMMENDED The fraction of partial Fourier information collected. Corresponds to DICOM Tag 0018, 9081 ”Partial Fourier”.
+%RECOMMENDED The fraction of partial Fourier information collected. 
+% Corresponds to DICOM Tag 0018, 9081 Partial Fourier.
 anat_json.PartialFourier=' ';
 
-%RECOMMENDED The direction where only partial Fourier information was collected. Corresponds to DICOM Tag 0018, 9036 “Partial Fourier Direction
+%RECOMMENDED The direction where only partial Fourier information was collected. 
+% Corresponds to DICOM Tag 0018, 9036 Partial Fourier Direction
 anat_json.PartialFourierDirection=' ';
 
-%REQUIRED if corresponding fieldmap data is present or when using multiple runs with different phase encoding directions
-%PhaseEncodingDirection is defined as the direction along which phase is was modulated which may result in visible distortions.
-anat_json.PhaseEncodingDirection=' ';
-
-
-
-%REQUIRED if corresponding fieldmap data is present. 
-%The “effective” sampling interval, specified in seconds, between lines in the phase-encoding direction, defined based on the size of the reconstructed image in the phase direction.  
-anat_json.EffectiveEchoSpacing=' ';
-
-
-%REQUIRED if corresponding “field/distortion” maps acquired with opposing phase encoding directions are present
-%This is actually the “effective” total readout time , defined as the readout duration, specified in seconds, that would have generated data with the given level of distortion.  It is NOT the actual, physical duration of the readout train
-anat_json.TotalReadoutTime=' ';
-
-%RECOMMENDED defined as the displacement of the water signal with respect to fat signal in the image. Water-fat shift (WFS) is expressed in number of pixels 
+%RECOMMENDED defined as the displacement of the water signal with respect to 
+% fat signal in the image. Water-fat shift (WFS) is expressed in number of pixels 
 anat_json.WaterFatShift=' ';
 
 %RECOMMENDED Number of lines in k-space acquired per excitation per image.
@@ -153,74 +163,89 @@ anat_json.EchoTrainLength=' ';
 
 
 
-%Timing Parameters metadata fields
+%% Timing Parameters metadata fields
 
-%REQUIRED if corresponding fieldmap data is present or the data comes from a multi echo sequence
-%The echo time (TE) for the acquisition, specified in seconds. 
-%Corresponds to DICOM Tag 0018, 0081 “Echo Time” 
+%REQUIRED if corresponding fieldmap data is present or the data comes from 
+% a multi echo sequence. The echo time (TE) for the acquisition, specified in seconds. 
+%Corresponds to DICOM Tag 0018, 0081 Echo Time
 anat_json.EchoTime=' ';
 
 
 
-%RECOMMENDED The inversion time (TI) for the acquisition, specified in seconds. Inversion time is the time after the middle of inverting RF pulse to middle of excitation pulse to detect the amount of longitudinal magnetization
+%RECOMMENDED The inversion time (TI) for the acquisition, specified in seconds. 
+% Inversion time is the time after the middle of inverting RF pulse to middle 
+% of excitation pulse to detect the amount of longitudinal magnetization
 anat_json.InversionTime=' ';
 
-%REQUIRED for sparse sequences that do not have the DelayTime field set. In addition without this parameter slice time correction will not be possible.
-%The time at which each slice was acquired within each volume (frame) of  the acquisition. 
-anat_json.SliceTiming=' ';
-
-
-%RECOMMENDED  Possible values: “i”, “j”, “k”, “i-”, “j-”, “k-” (the axis of the NIfTI data along which slices were acquired, and the direction in which SliceTiming is  defined with respect to). "i", "j", "k" identifiers correspond to the first, second and third axis of the data in the NIfTI file
-%When present ,the axis defined by SliceEncodingDirection  needs to be consistent with the ‘slice_dim’ field in the NIfTI header.
+%RECOMMENDED  Possible values: i, j, k, i-, j-, k- (the axis of the NIfTI data 
+% along which slices were acquired, and the direction in which SliceTiming 
+% is  defined with respect to). "i", "j", "k" identifiers correspond to the 
+% first, second and third axis of the data in the NIfTI file. When present 
+% ,the axis defined by SliceEncodingDirection  needs to be consistent with 
+% the slice_dim field in the NIfTI header.
 anat_json.SliceEncodingDirection=' ';
 
-%RECOMMENDED Actual dwell time (in seconds) of the receiver per point in the readout direction, including any oversampling.  For Siemens, this corresponds to DICOM field (0019,1018) (in ns).   
+%RECOMMENDED Actual dwell time (in seconds) of the receiver per point in the 
+% readout direction, including any oversampling.  For Siemens, this corresponds 
+% to DICOM field (0019,1018) (in ns).   
 anat_json.DwellTime=' ';
 
 
-%RF & Contrast metadata field
 
-%RECOMMENDED Flip angle for the acquisition, specified in degrees. Corresponds to: DICOM Tag 0018, 1314 “Flip Angle”.
+%% RF & Contrast metadata field
+
+%RECOMMENDED Flip angle for the acquisition, specified in degrees. 
+% Corresponds to: DICOM Tag 0018, 1314 Flip Angle.
 anat_json.FlipAngle=' ';
 
 
-%Slice Acceleration metadata field
+
+%% Slice Acceleration metadata field
 
 %RECOMMENDED The multiband factor, for multiband acquisitions.
 anat_json.MultibandAccelerationFactor=' ';
 
 
-%Anatomical landmarks metadata fields
 
-%RECOMMENDED Key:value pairs of any number of additional anatomical landmarks and their coordinates in voxel units
+%% Anatomical landmarks metadata fields
+
+%RECOMMENDED Key:value pairs of any number of additional anatomical landmarks 
+% and their coordinates in voxel units
 anat_json.AnatomicalLandmarkCoordinates=' ';
 
-%Institution information metadata fields
 
 
-%RECOMMENDED The name of the institution in charge of the equipment that produced the composite instances. Corresponds to DICOM Tag 0008, 0080 ”InstitutionName”.
+%% Institution information metadata fields
+
+%RECOMMENDED The name of the institution in charge of the equipment that 
+% produced the composite instances. Corresponds to 
+% DICOM Tag 0008, 0080 InstitutionName.
 anat_json.InstitutionName=' ';
 
-%RECOMMENDED The address of the institution in charge of the equipment that produced the composite instances. Corresponds to DICOM Tag 0008, 0081 ”InstitutionAddress”
+%RECOMMENDED The address of the institution in charge of the equipment that 
+% produced the composite instances. Corresponds to 
+% DICOM Tag 0008, 0081 InstitutionAddress
 anat_json.InstitutionAddress=' ';
 
-%RECOMMENDED The department in the  institution in charge of the equipment that produced the composite instances. Corresponds to DICOM Tag 0008, 1040 ”Institutional Department Name”.
+%RECOMMENDED The department in the  institution in charge of the equipment 
+% that produced the composite instances. Corresponds to 
+% DICOM Tag 0008, 1040 Institutional Department Name.
 anat_json.InstitutionalDepartmentName=' ';
 
 
 %OPTIONAL JSON field specific to anatomical scans
-%Active ingredient of agent.  Values MUST be one of: IODINE, GADOLINIUM, CARBON DIOXIDE, BARIUM, XENON Corresponds to DICOM Tag 0018,1048.
+%Active ingredient of agent.  Values MUST be one of: IODINE, GADOLINIUM, 
+% CARBON DIOXIDE, BARIUM, XENON Corresponds to DICOM Tag 0018,1048.
 anat_json.ContrastBolusIngredient=' ';
 
 
-json_options.indent               = '    '; % this makes the json look pretier when opened in a txt editor
+
+%% Write JSON
+json_options.indent = '    '; % this makes the json look pretier when opened in a txt editor
 
 jsonSaveDir = fileparts(anat_json_name);
 if ~isdir(jsonSaveDir)
     fprintf('Warning: directory to save json file does not exist, create: %s \n',jsonSaveDir)
 end
 
-
 jsonwrite(anat_json_name,anat_json,json_options)
-
-

--- a/matlabCode/createBIDS_anat_Short_T1w_json.m
+++ b/matlabCode/createBIDS_anat_Short_T1w_json.m
@@ -68,7 +68,7 @@ anat_json.TotalReadoutTime=' ';
 
 %REQUIRED if corresponding fieldmap data is present or the data comes from a multi echo sequence
 %The echo time (TE) for the acquisition, specified in seconds. 
-%Corresponds to DICOM Tag 0018, 0081 â€œEcho Timeâ€? 
+%Corresponds to DICOM Tag 0018, 0081 "Echo Time" 
 anat_json.EchoTime=' ';
 
 %REQUIRED for sparse sequences that do not have the DelayTime field set. 

--- a/matlabCode/createBIDS_anat_Short_T1w_json.m
+++ b/matlabCode/createBIDS_anat_Short_T1w_json.m
@@ -1,27 +1,31 @@
 %% Template Matlab script to create an BIDS compatible sub-01_ses-01_acq-ShortExample_run-01_T1w.json file
 % This example lists only the required  fields.
-% When adding additional metadata please use camelcase
+% When adding additional metadata please use CamelCase 
 % 
-%
 % anushkab, 2018
+% modified RG 201809
+
 %%
-clear all
+clear
 root_dir = '../';
 project_label = 'templates';
 sub_id = '01';
 ses_id = '01';
 
-%The OPTIONAL “acq-<label>” key/value pair corresponds to a custom label the user MAY use to distinguish a different set of parameters used for acquiring the same modality. 
+%The OPTIONAL acq-<label> key/value pair corresponds to a custom label 
+% the user MAY use to distinguish a different set of parameters used for 
+% acquiring the same modality. 
 
 acq_id = 'ShortExample'; 
 
 acquisition = 'anat';
 
-%OPTIONAL “ce-<label>” key/value can be used to distinguish sequences using different contrast enhanced images
-%OPTIONAL “rec-<label>” key/value can be used to distinguish different reconstruction algorithms 
+%OPTIONAL ce-<label> key/value can be used to distinguish sequences 
+% using different contrast enhanced images
+%OPTIONAL rec-<label> key/value can be used to distinguish different 
+% reconstruction algorithms 
 
 run_id='01';
-
 
 anat_json_name = fullfile(root_dir,project_label,...
   ['sub-' sub_id],...==
@@ -31,60 +35,56 @@ anat_json_name = fullfile(root_dir,project_label,...
               '_acq-' acq_id ...
               '_run-' run_id '_T1w.json']);
 
+          
+%%
 % Assign the fields in the Matlab structure that can be saved as a json.
-%
-
-%% all REQUIRED metadata fields for Magnetic Resonance Imaging data
+% all REQUIRED /RECOMMENDED /OPTIONAL metadata fields for Magnetic Resonance Imaging data
 
 
 
+%% In-Plane Spatial Encoding metadata fields
 
-
-%In-Plane Spatial Encoding metadata fields
-
-
-%REQUIRED if corresponding fieldmap data is present or when using multiple runs with different phase encoding directions
-%PhaseEncodingDirection is defined as the direction along which phase is was modulated which may result in visible distortions.
+%REQUIRED if corresponding fieldmap data is present or when using multiple 
+% runs with different phase encoding directions phaseEncodingDirection is 
+% defined as the direction along which phase is was modulated which may 
+% result in visible distortions.
 anat_json.PhaseEncodingDirection=' ';
 
-
-
-%REQUIRED if corresponding fieldmap data is present. 
-%The “effective” sampling interval, specified in seconds, between lines in the phase-encoding direction, defined based on the size of the reconstructed image in the phase direction.  
+%REQUIRED if corresponding fieldmap data is present. The effective sampling 
+% interval, specified in seconds, between lines in the phase-encoding direction, 
+% defined based on the size of the reconstructed image in the phase direction.  
 anat_json.EffectiveEchoSpacing=' ';
 
-
-%REQUIRED if corresponding “field/distortion” maps acquired with opposing phase encoding directions are present
-%This is actually the “effective” total readout time , defined as the readout duration, specified in seconds, that would have generated data with the given level of distortion.  It is NOT the actual, physical duration of the readout train
+%REQUIRED if corresponding field/distortion maps acquired with opposing phase 
+% encoding directions are present. This is actually the effective total 
+% readout time , defined as the readout duration, specified in seconds, 
+% that would have generated data with the given level of distortion.  
+% It is NOT the actual, physical duration of the readout train
 anat_json.TotalReadoutTime=' ';
 
 
 
-
-%Timing Parameters metadata fields
+%% Timing Parameters metadata fields
 
 %REQUIRED if corresponding fieldmap data is present or the data comes from a multi echo sequence
 %The echo time (TE) for the acquisition, specified in seconds. 
-%Corresponds to DICOM Tag 0018, 0081 “Echo Time” 
+%Corresponds to DICOM Tag 0018, 0081 “Echo Time�? 
 anat_json.EchoTime=' ';
 
-
-
-%REQUIRED for sparse sequences that do not have the DelayTime field set. In addition without this parameter slice time correction will not be possible.
-%The time at which each slice was acquired within each volume (frame) of  the acquisition. 
+%REQUIRED for sparse sequences that do not have the DelayTime field set. 
+% In addition without this parameter slice time correction will not be possible.
+%The time at which each slice was acquired within each volume (frame) of the acquisition. 
 anat_json.SliceTiming=' ';
 
 
 
-
-json_options.indent               = '    '; % this makes the json look pretier when opened in a txt editor
+%% Write JSON
+% this makes the json look pretier when opened in a txt editor
+json_options.indent = '    '; 
 
 jsonSaveDir = fileparts(anat_json_name);
 if ~isdir(jsonSaveDir)
     fprintf('Warning: directory to save json file does not exist, create: %s \n',jsonSaveDir)
 end
 
-
 jsonwrite(anat_json_name,anat_json,json_options)
-
-

--- a/matlabCode/createBIDS_bold_json_full.m
+++ b/matlabCode/createBIDS_bold_json_full.m
@@ -1,8 +1,10 @@
 %% Template Matlab script to create an BIDS compatible _bold.json file
 % This example lists all required and optional fields.
-% When adding additional metadata please use the camelcase version of DICOM ontology terms whenever possible.
+% When adding additional metadata please use CamelCase 
+% Use version of DICOM ontology terms whenever possible.
 %
 % DHermes, 2017
+% modified RG 201809
 
 %%
 
@@ -14,7 +16,6 @@ task_label = 'FullExample';
 run_label = '01';
 
 % you can also have acq- and proc-, but these are optional
-
 bold_json_name = fullfile(root_dir,project_label,[ 'sub-' sub_label ],...
     ['ses-' ses_label],...
     'func',...
@@ -23,57 +24,321 @@ bold_json_name = fullfile(root_dir,project_label,[ 'sub-' sub_label ],...
     '_task-' task_label ...
     '_run-' run_label '_bold.json']);
 
-%%
 
-% General fields, shared with MRI BIDS and MEG BIDS:
-% Required fields:
-bold_json.TaskName = ''; % Name of the task (for resting state use the ?rest? prefix). No two tasks should have the same name. Task label is derived from this field by removing all non alphanumeric ([a-zA-Z0-9]) characters. 
-bold_json.RepetitionTime = []; % The time in seconds between the beginning of an acquisition of one volume and the beginning of acquisition of the volume following it (TR). Please note that this definition includes time between scans (when no data has been acquired) in case of sparse acquisition schemes. This value needs to be consistent with the ?pixdim[4]? field (after accounting for units stored in ?xyzt_units? field) in the NIfTI header 
 
-% Recommended fields:
-bold_json.Manufacturer = ''; % Manufacturer of the equipment that produced the composite instances. Corresponds to DICOM Tag 0008, 0070 ?Manufacturer? .
-bold_json.ManufacturersModelName = ''; % Manufacturer`s model name of the equipment that produced the composite instances. Corresponds to DICOM Tag 0008, 1090 ?Manufacturers Model Name?.
-bold_json.MagenticFieldStrength = ''; % Nominal field strength of MR magnet in Tesla. Corresponds to DICOM Tag 0018,0087 ?Magnetic Field Strength? .
-bold_json.DeviceSerialNumber = ''; % The serial number of the equipment that produced the composite instances. A pseudonym can also be used to prevent the equipment from being identifiable, as long as each pseudonym is unique within the dataset.
-bold_json.SoftwareVersions = ''; % Manufacturer?s designation of software version of the equipment that produced the composite instances. Corresponds to DICOM Tag 0018, 1020 ?Software Versions?
-bold_json.ReceiveCoilName = '';% Information describing the receiver coil (Note: This isn?t a consistent field name across vendors. This name is the dcmstack output from a GE dataset, but it doesn?t seem to be simply coded into the dcmstack output for a Siemens scan). This doesn?t correspond to a term in the DICOM ontology
-bold_json.GradientSetType = '';% It should be possible to infer the gradient coil from the scanner model. If not, because of a custom upgrade or use of a gradient insert set, then the specifications of the actual gradient coil should be reported independently.
-bold_json.MRTransmitCoilSequence = '';% This is a relevant field if a non-standard transmit coil is used. Corresponds to DICOM Tag 0018, 9049 ?MR Transmit Coil Sequence?
-bold_json.MatrixCoilMode = '';% (If used) A method for reducing the number of independent channels by combining in analog the signals from multiple coil elements. There are typically different default modes when using un-accelerated or accelerated ( GRAPPA, SENSE) imaging.
-bold_json.CoilCombinationMethod = '';%  Almost all fMRI studies using phased-array coils use root-sum-of-squares (rSOS) combination, but other methods exist. The image reconstruction is changed by the coil combination method (as for the matrix coil mode above), so anything non-standard should be reported.
+%% Required fields
+% REQUIRED Name of the task (for resting state use the ?rest? prefix). No two tasks 
+% should have the same name. Task label is derived from this field by 
+% removing all non alphanumeric ([a-zA-Z0-9]) characters. 
+bold_json.TaskName = ''; 
 
-bold_json.PulseSequenceType = '';% A general description of the pulse sequence used for the scan (i.e. MPRAGE, Gradient Echo EPI, Spin Echo EPI, Multiband gradient echo EPI). 
-bold_json.PulseSequenceDetails = '';% Information beyond pulse sequence type that identifies the specific pulse sequence used (I.e. "Standard Siemens Sequence distributed with the VB17 software,? ?Siemens WIP ### version #.##,? or ?Sequence written by X using a version compiled on MM/DD/YYYY?).
-bold_json.NumberShots = '';% The number of RF excitations need to reconstruct a slice or volume. Please mind that this is not the same as Echo Train Length which denotes the number of lines of k-space collected after an excitation.
-bold_json.ParallelReductionFactorInPlane = '';% The parallel imaging (e.g, GRAPPA) factor. Use the denominator of the fraction of k-space encoded for each slice. For example, 2 means half of k-space is encoded. Corresponds to DICOM Tag 0018, 9069 ?Parallel Reduction Factor In-plane?.
-bold_json.ParallelAcquisitionTechnique = '';% The type of parallel imaging used (e.g. GRAPPA, SENSE). Corresponds to DICOM Tag 0018, 9078 ?Parallel Acquisition Technique?.
-bold_json.PartialFourier = '';% The fraction of partial Fourier information collected. Corresponds to DICOM Tag 0018, 9081 ?Partial Fourier?.
-bold_json.PartialFourierDirection = '';%The direction where only partial Fourier information was collected. Corresponds to DICOM Tag 0018, 9036 ?Partial Fourier Direction?. 
-bold_json.PhaseEncodingDirection  = '';% Possible values: ?i?, ?j?, ?k?, ?i-?, ?j-?, ?k-?. The letters ?i?, ?j?, ?k? correspond to the first, second and third axis of the data in the NIFTI file. The polarity of the phase encoding is assumed to go from zero index to maximum index unless ?-? sign is present (then the order is reversed - starting from the highest index instead of zero). PhaseEncodingDirection is defined as the direction along which phase is was modulated which may result in visible distortions. Note that this is not the same as the DICOM term InPlanePhaseEncodingDirection which can have ?ROW? or ?COL? values. This parameter is required if a corresponding fieldmap data is present or when using multiple runs with different phase encoding directions (which can be later used for field inhomogeneity correction).
-bold_json.EffectiveEchoSpacing  = '';% The sampling interval also known as the dwell time; required for unwarping distortions using field maps; expressed in seconds. See here how to calculate it. This parameter is required if a corresponding fieldmap data is present.
-bold_json.TotalReadoutTime  = ''; % defined as the time ( in seconds ) from the center of the first echo to the center of the last echo (aka ?FSL definition? - see here and here how to calculate it). This parameter is required if a corresponding multiple phase encoding directions fieldmap (see 8.9.4) data is present.
 
-bold_json.EchoTime = '';% The echo time (TE) for the acquisition, specified in seconds. This parameter is required if a corresponding fieldmap data is present or the data comes from a multi echo sequence. Corresponds to DICOM Tag 0018, 0081 ?Echo Time?.
-bold_json.InversionTime = '';% The inversion time (TI) for the acquisition, specified in seconds. Inversion time is the time after the middle of inverting RF pulse to middle of excitation pulse to detect the amount of longitudinal magnetization. Corresponds to DICOM Tag 0018, 0082 ?Inversion Time?.
-bold_json.SliceTiming = '';% The time at which each slice was acquired during the acquisition. Slice timing is not slice order - it describes the time (sec) of each slice acquisition in relation to the beginning of volume acquisition. It is described using a list of times (in JSON format) referring to the acquisition time for each slice. The list goes through slices along the slice axis in the slice encoding dimension (see below). This parameter is required for sparse sequences. In addition without this parameter slice time correction will not be possible.
-bold_json.SliceEncodingDirection = ''; % Possible values: ?i?, ?j?, ?k?, ?i-?, ?j-?, ?k-? (corresponding to the first, second and third axis of the data in the NIfTI file; ?-? sign corresponds to reverse order - starting from the highest index instead of zero). The axis of the NIfTI data along which a slices were acquired. This value needs to be consistent with the ?slice_dim? field in the NIfTI header.
-bold_json.NumberOfVolumesDiscardedByScanner = ''; %Number of volumes ("dummy scans") discarded by the user (as opposed to those discarded by the user post hoc) before saving the imaging file. For example, a sequence that automatically discards the first 4 volumes before saving would have this field as 4. A sequence that doesn't discard dummy scans would have this set to 0. Please note that the onsets recorded in the _event.tsv file should always refer to the beginning of the acquisition of the first volume in the corresponding imaging file - independent of the value of NumberOfVolumesDiscardedByScanner field.
-bold_json.NumberOfVolumesDiscardedByUser = '';% Number of volumes ("dummy scans") discarded by the user before including the file in the dataset. If possible, including all of the volumes is strongly recommended. Please note that the onsets recorded in the _event.tsv file should always refer to the beginning of the acquisition of the first volume in the corresponding imaging file - independent of the value of NumberOfVolumesDiscardedByUser field.
-bold_json.DelayTime = ''; % User specified time (in seconds) to delay the acquisition of data for the following volume. If the field is not present it is assumed to be set to zero. Corresponds to Siemens CSA header field lDelayTimeInTR . This field is compulsory for sparse sequences that do not have the SliceTiming field set to allowed for accurate calculation of "acquisition time".
+% REQUIRED The time in seconds between the beginning of an acquisition of 
+% one volume and the beginning of acquisition of the volume following it 
+% (TR). Please note that this definition includes time between scans 
+% (when no data has been acquired) in case of sparse acquisition schemes. 
+% This value needs to be consistent with the pixdim[4] field 
+% (after accounting for units stored in xyzt_units field) in the NIfTI header 
+bold_json.RepetitionTime = []; 
 
-bold_json.FlipAngle = '';% Flip angle for the acquisition, specified in degrees. Corresponds to: DICOM Tag 0018, 1314 ?Flip Angle?.
+%REQUIRED This field is mutually exclusive with RepetitionTime and DelayTime. 
+% If defined, this requires acquisition time (TA) be defined via either SliceTiming 
+% or AcquisitionDuration be defined.
+%
+% The time at which each volume was acquired during the acquisition. 
+% It is described using a list of times (in JSON format) referring to the 
+% onset of each volume in the BOLD series. The list must have the same length 
+% as the BOLD series, and the values must be non-negative and monotonically 
+% increasing. 
+bold_json.VolumeTiming = []; 
 
-bold_json.MultibandAccelerationFactor= ''; % The multiband factor, for multiband acquisitions.
+%RECOMMENDED This field is mutually exclusive with VolumeTiming.
+%
+% User specified time (in seconds) to delay the acquisition of 
+% data for the following volume. If the field is not present it is assumed 
+% to be set to zero. Corresponds to Siemens CSA header field lDelayTimeInTR.  
+% This field is REQUIRED for sparse sequences using the RepetitionTime field 
+% that do not have the SliceTiming field set to allowed for accurate calculation 
+% of "acquisition time". 
+bold_json.DelayTime = [];
 
-bold_json.Instructions = ''; % Text of the instructions given to participants before the scan. This is especially important in context of resting state fMRI and distinguishing between eyes open and eyes closed paradigms.
-bold_json.TaskDescription = '';% Longer description of the task.
-bold_json.CogAtlasID = '';% URL of the corresponding Cognitive Atlas Task term.
-bold_json.CogPOID = '';% URL of the corresponding CogPO term.
+%REQUIRED for sparse sequences that do not have the DelayTime field set. 
+% This parameter is required for sparse sequences. In addition without this 
+% parameter slice time correction will not be possible.
+%
+% In addition without this parameter slice time correction will not be possible.
+% The time at which each slice was acquired within each volume (frame) of  the acquisition. 
+% The time at which each slice was acquired during the acquisition. Slice 
+% timing is not slice order - it describes the time (sec) of each slice 
+% acquisition in relation to the beginning of volume acquisition. It is 
+% described using a list of times (in JSON format) referring to the acquisition 
+% time for each slice. The list goes through slices along the slice axis in the 
+% slice encoding dimension. 
+bold_json.SliceTiming = '';
 
-bold_json.InstitutionName = '';% The name of the institution in charge of the equipment that produced the composite instances. Corresponds to DICOM Tag 0008, 0080 ?InstitutionName?.
-bold_json.InstitutionAddress = '';% The address of the institution in charge of the equipment that produced the composite instances. Corresponds to DICOM Tag 0008, 0081 ?InstitutionAddress?.
+%RECOMMENDED This field is REQUIRED for sequences that are described with 
+% the VolumeTiming field and that not have the SliceTiming field set to allowed 
+% for accurate calculation of "acquisition time". This field is mutually 
+% exclusive with RepetitionTime.
+% 
+% Duration (in seconds) of volume acquisition. Corresponds to 
+% DICOM Tag 0018,9073 “Acquisition Duration”. 
+bold_json.AcquisitionDuration = [];
 
-json_options.indent = '    '; % this just makes the json file look prettier when opened in a text editor
+
+
+%% Required fields if using a fieldmap
+%REQUIRED if corresponding fieldmap data is present or when using multiple 
+% runs with different phase encoding directions PhaseEncodingDirection is 
+% defined as the direction along which phase is was modulated which may 
+% result in visible distortions.
+bold_json.PhaseEncodingDirection = '';
+
+%REQUIRED if corresponding fieldmap data is present. 
+% The effective sampling interval, specified in seconds, between lines in 
+% the phase-encoding direction, defined based on the size of the reconstructed 
+% image in the phase direction.  
+bold_json.EffectiveEchoSpacing = '';
+
+%REQUIRED if corresponding fieldmap data is present or the data comes from 
+% a multi echo sequence. The echo time (TE) for the acquisition, specified in seconds. 
+%Corresponds to DICOM Tag 0018, 0081 Echo Time
+bold_json.EchoTime = '';
+
+
+
+
+%% Recommended fields:
+
+
+%% Scanner Hardware metadata fields
+
+%RECOMMENDED Manufacturer of the equipment that produced the composite instances.
+bold_json.Manufacturer = '';
+
+%RECOMMENDED Manufacturer`s model name of the equipment that produced the 
+% composite instances. Corresponds to DICOM Tag 0008, 1090 Manufacturers Model Name.
+bold_json.ManufacturersModelName = '';
+
+%RECOMMENDED Nominal field strength of MR magnet in Tesla. Corresponds to 
+% DICOM Tag 0018,0087 Magnetic Field Strength.
+bold_json.MagneticFieldStrength = '';
+
+%RECOMMENDED The serial number of the equipment that produced the composite 
+% instances. Corresponds to DICOM Tag 0018, 1000 DeviceSerialNumber. 
+bold_json.DeviceSerialNumber = '';
+
+%RECOMMENDED Institution defined name of the machine that produced the composite 
+% instances. Corresponds to DICOM Tag 0008, 1010 Station Name
+bold_json.StationName= ' '; 
+
+%RECOMMENDED Manufacturer's designation of software version of the equipment 
+% that produced the composite instances. Corresponds to 
+% DICOM Tag 0018, 1020 Software Versions.
+bold_json.SoftwareVersions= ' ';
+
+%RECOMMENDED (Deprecated) Manufacturer's designation of the software of the 
+% device that created this Hardcopy Image (the printer). Corresponds to 
+% DICOM Tag 0018, 101A Hardcopy Device Software Version.
+bold_json.HardcopyDeviceSoftwareVersion = '';
+
+%RECOMMENDED Information describing the receiver coil
+bold_json.ReceiveCoilName= ' ' ;
+
+%RECOMMENDED Information describing the active/selected elements of the receiver coil. 
+anat_json.ReceiveCoilActiveElements = '';
+
+%RECOMMENDED the specifications of the actual gradient coil from the scanner model
+bold_json.GradientSetType = '';
+
+%RECOMMENDED This is a relevant field if a non-standard transmit coil is used. 
+% Corresponds to DICOM Tag 0018, 9049 MR Transmit Coil Sequence.
+bold_json.MRTransmitCoilSequence = '';
+
+%RECOMMENDED A method for reducing the number of independent channels by 
+% combining in analog the signals from multiple coil elements. There are 
+% typically different default modes when using un-accelerated or accelerated 
+% (e.g. GRAPPA, SENSE) imaging
+bold_json.MatrixCoilMode = '';
+
+%RECOMMENDED Almost all fMRI studies using phased-array coils use 
+% root-sum-of-squares (rSOS) combination, but other methods exist. 
+% The image reconstruction is changed by the coil combination method 
+% (as for the matrix coil mode above), so anything non-standard should be reported.
+bold_json.CoilCombinationMethod = '';
+
+
+
+%% Sequence Specifics metadata fields
+
+%RECOMMENDED A general description of the pulse sequence used for the scan 
+% (i.e. MPRAGE, Gradient Echo EPI, Spin Echo EPI, Multiband gradient echo EPI).
+bold_json.PulseSequenceType = '';
+
+%RECOMMENDED Description of the type of data acquired. Corresponds to 
+% DICOM Tag 0018, 0020 Sequence Sequence.
+bold_json.ScanningSequence = '';
+
+%RECOMMENDED Variant of the ScanningSequence. Corresponds to 
+% DICOM Tag 0018, 0021 Sequence Variant.
+bold_json.SequenceVariant = '';
+
+%RECOMMENDED Parameters of ScanningSequence. Corresponds to 
+% DICOM Tag 0018, 0022 Scan Options.
+bold_json.ScanOptions = '';
+
+%RECOMMENDED Manufacturer's designation of the sequence name. Corresponds 
+% to DICOM Tag 0018, 0024 Sequence Name.
+bold_json.SequenceName = '';
+
+%RECOMMENDED Information beyond pulse sequence type that identifies the 
+% specific pulse sequence used
+bold_json.PulseSequenceDetails = '';
+
+%RECOMMENDED Boolean stating if the image saved  has been corrected for 
+% gradient nonlinearities by the scanner sequence. 
+bold_json.NonlinearGradientCorrection = '';
+
+
+
+%% In-Plane Spatial Encoding metadata fields
+
+%RECOMMENDED The number of RF excitations need to reconstruct a slice or volume. 
+% Please mind that  this is not the same as Echo Train Length which denotes 
+% the number of lines of k-space collected after an excitation. 
+bold_json.NumberShots = '';
+
+%RECOMMENDED The parallel imaging (e.g, GRAPPA) factor. Use the denominator 
+% of the fraction of k-space encoded for each slice.
+bold_json.ParallelReductionFactorInPlane = '';
+
+%RECOMMENDED The type of parallel imaging used (e.g. GRAPPA, SENSE). 
+% Corresponds to DICOM Tag 0018, 9078 Parallel Acquisition Technique. 
+bold_json.ParallelAcquisitionTechnique = '';
+
+%RECOMMENDED The fraction of partial Fourier information collected. 
+% Corresponds to DICOM Tag 0018, 9081 Partial Fourier.
+bold_json.PartialFourier = '';
+
+%RECOMMENDED The direction where only partial Fourier information was collected. 
+% Corresponds to DICOM Tag 0018, 9036 Partial Fourier Direction
+bold_json.PartialFourierDirection = '';
+
+%RECOMMENDED defined as the displacement of the water signal with respect to 
+% fat signal in the image. Water-fat shift (WFS) is expressed in number of pixels 
+bold_json.WaterFatShift = '';
+
+%RECOMMENDED Number of lines in k-space acquired per excitation per image.
+bold_json.EchoTrainLength = '';
+
+
+
+%% Timing Parameters metadata fields
+
+%RECOMMENDED The inversion time (TI) for the acquisition, specified in seconds. 
+% Inversion time is the time after the middle of inverting RF pulse to middle 
+% of excitation pulse to detect the amount of longitudinal magnetization
+bold_json.InversionTime = '';
+
+%RECOMMENDED  Possible values: i, j, k, i-, j-, k- (the axis of the NIfTI data 
+% along which slices were acquired, and the direction in which SliceTiming 
+% is  defined with respect to). "i", "j", "k" identifiers correspond to the 
+% first, second and third axis of the data in the NIfTI file. When present 
+% ,the axis defined by SliceEncodingDirection  needs to be consistent with 
+% the slice_dim field in the NIfTI header.
+bold_json.SliceEncodingDirection = '';
+
+%RECOMMENDED Actual dwell time (in seconds) of the receiver per point in the 
+% readout direction, including any oversampling.  For Siemens, this corresponds 
+% to DICOM field (0019,1018) (in ns).   
+bold_json.DwellTime = '';
+
+%RECOMMENDED TotalReadoutTime defined as the time ( in seconds ) from the center of the first echo to 
+% the center of the last echo (aka ?FSL definition? - see here and here how 
+% to calculate it). This parameter is required if a corresponding multiple 
+% phase encoding directions fieldmap (see 8.9.4) data is present.
+bold_json.TotalReadoutTime = ''; 
+
+%RECOMMENDED Duration (in seconds) from trigger delivery to scan onset. 
+% This delay is commonly caused by adjustments and loading times. This specification 
+% is entirely independent of NumberOfVolumesDiscardedByScanner or 
+% NumberOfVolumesDiscardedByUser, as the delay precedes the acquisition.
+bold_json.DelayAfterTrigger = [];
+
+%RECOMMENDED Number of volumes ("dummy scans") discarded by the user (as opposed to those 
+% discarded by the user post hoc) before saving the imaging file. For example, 
+% a sequence that automatically discards the first 4 volumes before saving 
+% would have this field as 4. A sequence that doesn't discard dummy scans would 
+% have this set to 0. Please note that the onsets recorded in the _event.tsv 
+% file should always refer to the beginning of the acquisition of the first 
+% volume in the corresponding imaging file - independent of the value of 
+% NumberOfVolumesDiscardedByScanner field.
+bold_json.NumberOfVolumesDiscardedByScanner = ''; 
+
+%RECOMMENDED Number of volumes ("dummy scans") discarded by the user before including 
+% the file in the dataset. If possible, including all of the volumes is 
+% strongly recommended. Please note that the onsets recorded in the _event.tsv 
+% file should always refer to the beginning of the acquisition of the first 
+% volume in the corresponding imaging file - independent of the value of 
+% NumberOfVolumesDiscardedByUser field.
+bold_json.NumberOfVolumesDiscardedByUser = '';
+
+
+%% RF & Contrast metadata field
+
+%RECOMMENDED Flip angle for the acquisition, specified in degrees. 
+% Corresponds to: DICOM Tag 0018, 1314 Flip Angle.
+bold_json.FlipAngle = '';
+
+
+
+%% Slice Acceleration metadata field
+
+%RECOMMENDED The multiband factor, for multiband acquisitions.
+bold_json.MultibandAccelerationFactor = '';
+
+
+
+%% Task metadata field
+
+%RECOMMENDED Text of the instructions given to participants before the scan. 
+% This is especially important in context of resting state fMRI and 
+% distinguishing between eyes open and eyes closed paradigms.
+bold_json.Instructions = ''; 
+
+%RECOMMENDED Longer description of the task.
+bold_json.TaskDescription = '';
+
+%RECOMMENDED URL of the corresponding Cognitive Atlas Task term.
+bold_json.CogAtlasID = '';
+
+%RECOMMENDED URL of the corresponding CogPO term.
+bold_json.CogPOID = '';
+
+
+
+%% Institution information metadata fields
+
+%RECOMMENDED The name of the institution in charge of the equipment that 
+% produced the composite instances. Corresponds to 
+% DICOM Tag 0008, 0080 InstitutionName.
+bold_json.InstitutionName = '';
+
+%RECOMMENDED The address of the institution in charge of the equipment that 
+% produced the composite instances. Corresponds to 
+% DICOM Tag 0008, 0081 InstitutionAddress
+bold_json.InstitutionAddress = '';
+
+%RECOMMENDED The department in the  institution in charge of the equipment 
+% that produced the composite instances. Corresponds to 
+% DICOM Tag 0008, 1040 Institutional Department Name.
+bold_json.InstitutionalDepartmentName = '';
+
+
+
+%% Write
+% this just makes the json file look prettier when opened in a text editor
+json_options.indent = '    '; 
 
 jsonSaveDir = fileparts(bold_json_name);
 if ~isdir(jsonSaveDir)

--- a/matlabCode/createBIDS_bold_json_full.m
+++ b/matlabCode/createBIDS_bold_json_full.m
@@ -82,7 +82,7 @@ bold_json.SliceTiming = '';
 % exclusive with RepetitionTime.
 % 
 % Duration (in seconds) of volume acquisition. Corresponds to 
-% DICOM Tag 0018,9073 “Acquisition Duration”. 
+% DICOM Tag 0018,9073 "Acquisition Duration". 
 bold_json.AcquisitionDuration = [];
 
 
@@ -102,7 +102,7 @@ bold_json.EffectiveEchoSpacing = '';
 
 %REQUIRED if corresponding fieldmap data is present or the data comes from 
 % a multi echo sequence. The echo time (TE) for the acquisition, specified in seconds. 
-%Corresponds to DICOM Tag 0018, 0081 Echo Time
+%Corresponds to DICOM Tag 0018, 0081 "Echo Time"
 bold_json.EchoTime = '';
 
 
@@ -117,15 +117,16 @@ bold_json.EchoTime = '';
 bold_json.Manufacturer = '';
 
 %RECOMMENDED Manufacturer`s model name of the equipment that produced the 
-% composite instances. Corresponds to DICOM Tag 0008, 1090 Manufacturers Model Name.
+% composite instances. Corresponds to DICOM Tag 0008, 1090 "Manufacturers
+% Model Name"
 bold_json.ManufacturersModelName = '';
 
 %RECOMMENDED Nominal field strength of MR magnet in Tesla. Corresponds to 
-% DICOM Tag 0018,0087 Magnetic Field Strength.
+% DICOM Tag 0018,0087 "Magnetic Field Strength".
 bold_json.MagneticFieldStrength = '';
 
 %RECOMMENDED The serial number of the equipment that produced the composite 
-% instances. Corresponds to DICOM Tag 0018, 1000 DeviceSerialNumber. 
+% instances. Corresponds to DICOM Tag 0018, 1000 "DeviceSerialNumber". 
 bold_json.DeviceSerialNumber = '';
 
 %RECOMMENDED Institution defined name of the machine that produced the composite 
@@ -134,12 +135,12 @@ bold_json.StationName= ' ';
 
 %RECOMMENDED Manufacturer's designation of software version of the equipment 
 % that produced the composite instances. Corresponds to 
-% DICOM Tag 0018, 1020 Software Versions.
+% DICOM Tag 0018, 1020 "Software Versions".
 bold_json.SoftwareVersions= ' ';
 
 %RECOMMENDED (Deprecated) Manufacturer's designation of the software of the 
 % device that created this Hardcopy Image (the printer). Corresponds to 
-% DICOM Tag 0018, 101A Hardcopy Device Software Version.
+% DICOM Tag 0018, 101 "Hardcopy Device Software Version".
 bold_json.HardcopyDeviceSoftwareVersion = '';
 
 %RECOMMENDED Information describing the receiver coil
@@ -152,7 +153,7 @@ anat_json.ReceiveCoilActiveElements = '';
 bold_json.GradientSetType = '';
 
 %RECOMMENDED This is a relevant field if a non-standard transmit coil is used. 
-% Corresponds to DICOM Tag 0018, 9049 MR Transmit Coil Sequence.
+% Corresponds to DICOM Tag 0018, 9049 "MR Transmit Coil Sequence".
 bold_json.MRTransmitCoilSequence = '';
 
 %RECOMMENDED A method for reducing the number of independent channels by 
@@ -176,19 +177,19 @@ bold_json.CoilCombinationMethod = '';
 bold_json.PulseSequenceType = '';
 
 %RECOMMENDED Description of the type of data acquired. Corresponds to 
-% DICOM Tag 0018, 0020 Sequence Sequence.
+% DICOM Tag 0018, 0020 "Sequence Sequence".
 bold_json.ScanningSequence = '';
 
 %RECOMMENDED Variant of the ScanningSequence. Corresponds to 
-% DICOM Tag 0018, 0021 Sequence Variant.
+% DICOM Tag 0018, 0021 "Sequence Variant".
 bold_json.SequenceVariant = '';
 
 %RECOMMENDED Parameters of ScanningSequence. Corresponds to 
-% DICOM Tag 0018, 0022 Scan Options.
+% DICOM Tag 0018, 0022 "Scan Options".
 bold_json.ScanOptions = '';
 
 %RECOMMENDED Manufacturer's designation of the sequence name. Corresponds 
-% to DICOM Tag 0018, 0024 Sequence Name.
+% to DICOM Tag 0018, 0024 "Sequence Name".
 bold_json.SequenceName = '';
 
 %RECOMMENDED Information beyond pulse sequence type that identifies the 
@@ -213,15 +214,15 @@ bold_json.NumberShots = '';
 bold_json.ParallelReductionFactorInPlane = '';
 
 %RECOMMENDED The type of parallel imaging used (e.g. GRAPPA, SENSE). 
-% Corresponds to DICOM Tag 0018, 9078 Parallel Acquisition Technique. 
+% Corresponds to DICOM Tag 0018, 9078 "Parallel Acquisition Technique". 
 bold_json.ParallelAcquisitionTechnique = '';
 
 %RECOMMENDED The fraction of partial Fourier information collected. 
-% Corresponds to DICOM Tag 0018, 9081 Partial Fourier.
+% Corresponds to DICOM Tag 0018, 9081 "Partial Fourier".
 bold_json.PartialFourier = '';
 
 %RECOMMENDED The direction where only partial Fourier information was collected. 
-% Corresponds to DICOM Tag 0018, 9036 Partial Fourier Direction
+% Corresponds to DICOM Tag 0018, 9036 "Partial Fourier Direction"
 bold_json.PartialFourierDirection = '';
 
 %RECOMMENDED defined as the displacement of the water signal with respect to 
@@ -240,7 +241,7 @@ bold_json.EchoTrainLength = '';
 % of excitation pulse to detect the amount of longitudinal magnetization
 bold_json.InversionTime = '';
 
-%RECOMMENDED  Possible values: i, j, k, i-, j-, k- (the axis of the NIfTI data 
+%RECOMMENDED  Possible values: "i", "j", "k", "i-", "j-", "k-" (the axis of the NIfTI data 
 % along which slices were acquired, and the direction in which SliceTiming 
 % is  defined with respect to). "i", "j", "k" identifiers correspond to the 
 % first, second and third axis of the data in the NIfTI file. When present 
@@ -254,7 +255,7 @@ bold_json.SliceEncodingDirection = '';
 bold_json.DwellTime = '';
 
 %RECOMMENDED TotalReadoutTime defined as the time ( in seconds ) from the center of the first echo to 
-% the center of the last echo (aka ?FSL definition? - see here and here how 
+% the center of the last echo (aka "FSL definition" - see here and here how 
 % to calculate it). This parameter is required if a corresponding multiple 
 % phase encoding directions fieldmap (see 8.9.4) data is present.
 bold_json.TotalReadoutTime = ''; 
@@ -287,7 +288,7 @@ bold_json.NumberOfVolumesDiscardedByUser = '';
 %% RF & Contrast metadata field
 
 %RECOMMENDED Flip angle for the acquisition, specified in degrees. 
-% Corresponds to: DICOM Tag 0018, 1314 Flip Angle.
+% Corresponds to: DICOM Tag 0018, 1314 "Flip Angle".
 bold_json.FlipAngle = '';
 
 
@@ -321,17 +322,17 @@ bold_json.CogPOID = '';
 
 %RECOMMENDED The name of the institution in charge of the equipment that 
 % produced the composite instances. Corresponds to 
-% DICOM Tag 0008, 0080 InstitutionName.
+% DICOM Tag 0008, 0080 "InstitutionName".
 bold_json.InstitutionName = '';
 
 %RECOMMENDED The address of the institution in charge of the equipment that 
 % produced the composite instances. Corresponds to 
-% DICOM Tag 0008, 0081 InstitutionAddress
+% DICOM Tag 0008, 0081 "InstitutionAddress"
 bold_json.InstitutionAddress = '';
 
 %RECOMMENDED The department in the  institution in charge of the equipment 
 % that produced the composite instances. Corresponds to 
-% DICOM Tag 0008, 1040 Institutional Department Name.
+% DICOM Tag 0008, 1040 "Institutional Department Name".
 bold_json.InstitutionalDepartmentName = '';
 
 

--- a/matlabCode/createBIDS_bold_json_short.m
+++ b/matlabCode/createBIDS_bold_json_short.m
@@ -29,7 +29,7 @@ bold_json_name = fullfile(root_dir,project_label,[ 'sub-' sub_label ],...
 
 
 %% Required fields
-% REQUIRED Name of the task (for resting state use the ?rest? prefix). No two tasks 
+% REQUIRED Name of the task (for resting state use the "rest" prefix). No two tasks 
 % should have the same name. Task label is derived from this field by 
 % removing all non alphanumeric ([a-zA-Z0-9]) characters. 
 bold_json.TaskName = ''; 
@@ -104,7 +104,7 @@ bold_json.EffectiveEchoSpacing = '';
 
 %REQUIRED if corresponding fieldmap data is present or the data comes from 
 % a multi echo sequence. The echo time (TE) for the acquisition, specified in seconds. 
-%Corresponds to DICOM Tag 0018, 0081 Echo Time
+%Corresponds to DICOM Tag 0018, 0081 "Echo Time"
 bold_json.EchoTime = '';
 
 

--- a/matlabCode/createBIDS_bold_json_short.m
+++ b/matlabCode/createBIDS_bold_json_short.m
@@ -1,7 +1,10 @@
 %% Template Matlab script to create an BIDS compatible _bold.json file
 % This example only lists the required fields.
+% When adding additional metadata please use CamelCase 
+% Use version of DICOM ontology terms whenever possible.
 %
 % DHermes, 2017
+% modified RG 201809
 
 %%
 
@@ -24,16 +27,94 @@ bold_json_name = fullfile(root_dir,project_label,[ 'sub-' sub_label ],...
 
 %%
 
-% General fields, shared with MRI BIDS and MEG BIDS:
-% Required fields:
-bold_json.TaskName = ''; % Name of the task (for resting state use the ?rest? prefix). No two tasks should have the same name. Task label is derived from this field by removing all non alphanumeric ([a-zA-Z0-9]) characters. 
-bold_json.RepetitionTime = ''; % The time in seconds between the beginning of an acquisition of one volume and the beginning of acquisition of the volume following it (TR). Please note that this definition includes time between scans (when no data has been acquired) in case of sparse acquisition schemes. This value needs to be consistent with the ?pixdim[4]? field (after accounting for units stored in ?xyzt_units? field) in the NIfTI header 
 
-json_options.indent = '    '; % this just makes the json file look prettier when opened in a text editor
+%% Required fields
+% REQUIRED Name of the task (for resting state use the ?rest? prefix). No two tasks 
+% should have the same name. Task label is derived from this field by 
+% removing all non alphanumeric ([a-zA-Z0-9]) characters. 
+bold_json.TaskName = ''; 
+
+
+% REQUIRED The time in seconds between the beginning of an acquisition of 
+% one volume and the beginning of acquisition of the volume following it 
+% (TR). Please note that this definition includes time between scans 
+% (when no data has been acquired) in case of sparse acquisition schemes. 
+% This value needs to be consistent with the pixdim[4] field 
+% (after accounting for units stored in xyzt_units field) in the NIfTI header 
+bold_json.RepetitionTime = []; 
+
+%REQUIRED This field is mutually exclusive with RepetitionTime and DelayTime. 
+% If defined, this requires acquisition time (TA) be defined via either SliceTiming 
+% or AcquisitionDuration be defined.
+%
+% The time at which each volume was acquired during the acquisition. 
+% It is described using a list of times (in JSON format) referring to the 
+% onset of each volume in the BOLD series. The list must have the same length 
+% as the BOLD series, and the values must be non-negative and monotonically 
+% increasing. 
+bold_json.VolumeTiming = []; 
+
+%RECOMMENDED This field is mutually exclusive with VolumeTiming.
+%
+% User specified time (in seconds) to delay the acquisition of 
+% data for the following volume. If the field is not present it is assumed 
+% to be set to zero. Corresponds to Siemens CSA header field lDelayTimeInTR.  
+% This field is REQUIRED for sparse sequences using the RepetitionTime field 
+% that do not have the SliceTiming field set to allowed for accurate calculation 
+% of "acquisition time". 
+bold_json.DelayTime = [];
+
+%REQUIRED for sparse sequences that do not have the DelayTime field set. 
+% This parameter is required for sparse sequences. In addition without this 
+% parameter slice time correction will not be possible.
+%
+% In addition without this parameter slice time correction will not be possible.
+% The time at which each slice was acquired within each volume (frame) of  the acquisition. 
+% The time at which each slice was acquired during the acquisition. Slice 
+% timing is not slice order - it describes the time (sec) of each slice 
+% acquisition in relation to the beginning of volume acquisition. It is 
+% described using a list of times (in JSON format) referring to the acquisition 
+% time for each slice. The list goes through slices along the slice axis in the 
+% slice encoding dimension. 
+bold_json.SliceTiming = '';
+
+%RECOMMENDED This field is REQUIRED for sequences that are described with 
+% the VolumeTiming field and that not have the SliceTiming field set to allowed 
+% for accurate calculation of "acquisition time". This field is mutually 
+% exclusive with RepetitionTime.
+% 
+% Duration (in seconds) of volume acquisition. Corresponds to 
+% DICOM Tag 0018,9073 “Acquisition Duration”. 
+bold_json.AcquisitionDuration = [];
+
+
+
+%% Required fields if using a fieldmap
+%REQUIRED if corresponding fieldmap data is present or when using multiple 
+% runs with different phase encoding directions PhaseEncodingDirection is 
+% defined as the direction along which phase is was modulated which may 
+% result in visible distortions.
+bold_json.PhaseEncodingDirection = '';
+
+%REQUIRED if corresponding fieldmap data is present. 
+% The effective sampling interval, specified in seconds, between lines in 
+% the phase-encoding direction, defined based on the size of the reconstructed 
+% image in the phase direction.  
+bold_json.EffectiveEchoSpacing = '';
+
+%REQUIRED if corresponding fieldmap data is present or the data comes from 
+% a multi echo sequence. The echo time (TE) for the acquisition, specified in seconds. 
+%Corresponds to DICOM Tag 0018, 0081 Echo Time
+bold_json.EchoTime = '';
+
+
+%% Write
+% this just makes the json file look prettier when opened in a text editor
+json_options.indent = '    '; 
 
 jsonSaveDir = fileparts(bold_json_name);
 if ~isdir(jsonSaveDir)
-    fprintf('Warning: directory to save json file does not exist, create: %s \n',jsonSaveDir)
+    fprintf('Warning: directory to save json file does not exist, first create: %s \n',jsonSaveDir)
 end
 
 jsonwrite(bold_json_name,bold_json,json_options)

--- a/matlabCode/createBIDS_dataset_description_json.m
+++ b/matlabCode/createBIDS_dataset_description_json.m
@@ -31,7 +31,7 @@ dd_json.BIDSVersion = '1.0.2'; % The version of the BIDS standard that was used
 
 %%  Recommended fields:
 
-dd_json.License = '';% what license is this dataset distributed under? The 
+dd_json.License = '';% what license is this dataset distributed under The 
 % use of license name abbreviations is suggested for specifying a license. 
 % A list of common licenses with suggested abbreviations can be found in appendix III.
 

--- a/matlabCode/createBIDS_dataset_description_json.m
+++ b/matlabCode/createBIDS_dataset_description_json.m
@@ -31,7 +31,7 @@ dd_json.BIDSVersion = '1.0.2'; % The version of the BIDS standard that was used
 
 %%  Recommended fields:
 
-dd_json.License = '';% what license is this dataset distributed under The 
+dd_json.License = '';% what license is this dataset distributed under? The 
 % use of license name abbreviations is suggested for specifying a license. 
 % A list of common licenses with suggested abbreviations can be found in appendix III.
 

--- a/matlabCode/createBIDS_dataset_description_json.m
+++ b/matlabCode/createBIDS_dataset_description_json.m
@@ -1,11 +1,12 @@
 %% Template Matlab script to create an BIDS compatible dataset_description.json file
 % This example lists all required and optional fields.
-% When adding additional metadata please use camelcase
+% When adding additional metadata please use CamelCase 
 %
 % DHermes, 2017
+% modified RG 201809
 
 %%
-clear all
+clear
 root_dir = '.';
 project_label = 'templates';
 json_label = 'dataset_description';
@@ -14,22 +15,50 @@ json_label = 'dataset_description';
 dataset_description_json_name = fullfile(root_dir,project_label,...
     'dataset_description.json');
 
-%%
 
-% General fields, shared with MRI BIDS and MEG BIDS:
-% Required fields:
+
+%% General fields, shared with MRI BIDS and MEG BIDS:
+
+
+
+%%  Required fields:
+
 dd_json.Name = ''; % name of the dataset
-dd_json.BIDSVersion = '1.0.2'; % The version of the BIDS standard that was used
-% Recommended fields:
-dd_json.License = '';% what license is this dataset distributed under? The use of license name abbreviations is suggested for specifying a license. A list of common licenses with suggested abbreviations can be found in appendix III.
-dd_json.Authors = {'','',''};% List of individuals who contributed to the creation/curation of the dataset
-dd_json.Acknowledgements = ''; % who should be acknowledge in helping to collect the data
-dd_json.HowToAcknowledge = ''; % Instructions how researchers using this dataset should acknowledge the original authors. This field can also be used to define a publication that should be cited in publications that use the dataset,
-dd_json.Funding = {'','',''}; % sources of funding (grant numbers)
-dd_json.ReferencesAndLinks = {'','',''};% a list of references to publication that contain information on the dataset, or links.
-dd_json.DatasetDOI = ''; %the Document Object Identifier of the dataset (not the corresponding paper).
 
-json_options.indent = '    '; % this just makes the json file look prettier when opened in a text editor
+dd_json.BIDSVersion = '1.0.2'; % The version of the BIDS standard that was used
+
+
+
+%%  Recommended fields:
+
+dd_json.License = '';% what license is this dataset distributed under? The 
+% use of license name abbreviations is suggested for specifying a license. 
+% A list of common licenses with suggested abbreviations can be found in appendix III.
+
+dd_json.Authors = {'','',''};% List of individuals who contributed to the 
+% creation/curation of the dataset
+
+dd_json.Acknowledgements = ''; % who should be acknowledge in helping to collect the data
+
+dd_json.HowToAcknowledge = ''; % Instructions how researchers using this 
+% dataset should acknowledge the original authors. This field can also be used 
+% to define a publication that should be cited in publications that use the
+% dataset.
+
+dd_json.Funding = {'','',''}; % sources of funding (grant numbers)
+
+dd_json.ReferencesAndLinks = {'','',''};% a list of references to 
+% publication that contain information on the dataset, or links.
+
+dd_json.DatasetDOI = ''; %the Document Object Identifier of the dataset 
+% (not the corresponding paper).
+
+
+
+%% Write JSON
+
+json_options.indent = '    '; % this just makes the json file look prettier 
+% when opened in a text editor
 
 jsonSaveDir = fileparts(dataset_description_json_name);
 if ~isdir(jsonSaveDir)
@@ -37,6 +66,3 @@ if ~isdir(jsonSaveDir)
 end
 
 jsonwrite(dataset_description_json_name,dd_json,json_options)
-
-
-

--- a/matlabCode/createBIDS_fmap_json.m
+++ b/matlabCode/createBIDS_fmap_json.m
@@ -139,7 +139,7 @@ task_label = 'Case4';
 run_label = '01';
 
 dir_label = 'LR'; %dir_label value can be set to arbitrary alphanumeric 
-% label ([a-zA-Z0-9]+ for example ?LR? or ?AP?) that can help users to 
+% label ([a-zA-Z0-9]+ for example "LR" or "AP") that can help users to 
 % distinguish between different files, but should not be used to infer any 
 % scanning parameters (such as phase encoding directions) of the corresponding sequence.
 

--- a/matlabCode/createBIDS_fmap_json.m
+++ b/matlabCode/createBIDS_fmap_json.m
@@ -1,10 +1,14 @@
 %% Template Matlab script to create an BIDS compatible _fmap.json file
 % There are different cases, see BIDS spec 1.0.2 paragraph 8.9
+% This example lists all required and optional fields.
+% When adding additional metadata please use CamelCase 
 %
 % DHermes, 2017
+% modified RG 201809
+
 
 %% 8.9.1 Case 1: Phase difference image and at least one magnitude image
-clear all
+clear
 
 root_dir = '../';
 project_label = 'templates';
@@ -25,10 +29,14 @@ fmap_json_name = fullfile(root_dir,project_label,[ 'sub-' sub_label ],...
 
 fmap_json.EchoTime1 = ''; 
 fmap_json.EchoTime2 = ''; 
-fmap_json.IntendedFor = ''; % Fieldmap data are linked to a specific scan(s) it was acquired for by filling the IntendedFor field. The IntendedFor field may contain one or more filenames with paths relative to the subject subfolder. The pathneeds to use forward slashes instead of backward slashes.
+fmap_json.IntendedFor = ''; % Fieldmap data are linked to a specific scan(s) 
+% it was acquired for by filling the IntendedFor field. The IntendedFor field 
+% may contain one or more filenames with paths relative to the subject subfolder. 
+% The pathneeds to use forward slashes instead of backward slashes.
 
-json_options.indent = '    '; % this just makes the json file look prettier when opened in a text editor
 
+json_options.indent = '    '; % this just makes the json file look prettier 
+% when opened in a text editor
 jsonSaveDir = fileparts(fmap_json_name);
 if ~isdir(jsonSaveDir)
     fprintf('Warning: directory to save json file does not exist, create: %s \n',jsonSaveDir)
@@ -36,8 +44,9 @@ end
 jsonwrite(fmap_json_name,fmap_json,json_options)
 
 
+
 %% 8.9.2 Case 2: Two phase images and two magnitude images
-clear all
+clear
 
 root_dir = '../';
 project_label = 'templates';
@@ -62,24 +71,31 @@ fmap2_json_name = fullfile(root_dir,project_label,[ 'sub-' sub_label ],...
     '_run-' run_label '_phase2.json']);
 
 fmap1_json.EchoTime = ''; 
-fmap1_json.IntendedFor = ''; 
+fmap1_json.IntendedFor = ''; % Fieldmap data are linked to a specific scan(s) 
+% it was acquired for by filling the IntendedFor field. The IntendedFor field 
+% may contain one or more filenames with paths relative to the subject subfolder. 
+% The pathneeds to use forward slashes instead of backward slashes.
 
 fmap2_json.EchoTime = ''; 
-fmap2_json.IntendedFor = ''; 
+fmap2_json.IntendedFor = ''; % Fieldmap data are linked to a specific scan(s) 
+% it was acquired for by filling the IntendedFor field. The IntendedFor field 
+% may contain one or more filenames with paths relative to the subject subfolder. 
+% The pathneeds to use forward slashes instead of backward slashes.
 
-jsonSaveDir = fileparts(fmap1_json_name);
+json_options.indent = '    '; % this just makes the json file look prettier 
+% when opened in a text editor
+jsonSaveDir = fileparts(fmap_json_name);
 if ~isdir(jsonSaveDir)
     fprintf('Warning: directory to save json file does not exist, create: %s \n',jsonSaveDir)
 end
-json_options.indent = '    '; % this just makes the json file look prettier when opened in a text editor
-
 jsonwrite(fmap1_json_name,fmap1_json,json_options)
 jsonwrite(fmap2_json_name,fmap2_json,json_options)
 
 
+
 %% 8.9.3 Case 3: A single, real fieldmap image (showing the field inhomogeneity in each voxel)
 
-clear all
+clear 
 root_dir = '../';
 project_label = 'templates';
 sub_label = '01';
@@ -95,21 +111,26 @@ fmap_json_name = fullfile(root_dir,project_label,[ 'sub-' sub_label ],...
     '_task-' task_label ...
     '_run-' run_label '_fieldmap.json']);
 
-fmap_json.Units = ''; % The possible options are: ?Hz?, ?rad/s?, or ?Tesla?.
-fmap_json.IntendedFor = ''; % Fieldmap data are linked to a specific scan(s) it was acquired for by filling the IntendedFor field. The IntendedFor field may contain one or more filenames with paths relative to the subject subfolder. The pathneeds to use forward slashes instead of backward slashes.
+fmap_json.Units = ''; % The possible options are: Hz, rad/s, or Tesla.
+fmap_json.IntendedFor = ''; % Fieldmap data are linked to a specific scan(s) 
+% it was acquired for by filling the IntendedFor field. The IntendedFor field 
+% may contain one or more filenames with paths relative to the subject subfolder. 
+% The pathneeds to use forward slashes instead of backward slashes.
 
+
+json_options.indent = '    '; % this just makes the json file look prettier 
+% when opened in a text editor
 jsonSaveDir = fileparts(fmap_json_name);
 if ~isdir(jsonSaveDir)
-    fprintf('Warning: directory to save json file does not exist: %s \n',jsonSaveDir)
+    fprintf('Warning: directory to save json file does not exist, create: %s \n',jsonSaveDir)
 end
-json_options.indent = '    '; % this just makes the json file look prettier when opened in a text editor
-
 jsonwrite(fmap_json_name,fmap_json,json_options)
+
 
 
 %% 8.9.4 Case 4: Multiple phase encoded directions (topup)
 
-clear all
+clear
 root_dir = '../';
 project_label = 'templates';
 sub_label = '01';
@@ -117,7 +138,10 @@ ses_label = '01';
 task_label = 'Case4';
 run_label = '01';
 
-dir_label = 'LR'; %dir_label value can be set to arbitrary alphanumeric label ([a-zA-Z0-9]+ for example ?LR? or ?AP?) that can help users to distinguish between different files, but should not be used to infer any scanning parameters (such as phase encoding directions) of the corresponding sequence.
+dir_label = 'LR'; %dir_label value can be set to arbitrary alphanumeric 
+% label ([a-zA-Z0-9]+ for example ?LR? or ?AP?) that can help users to 
+% distinguish between different files, but should not be used to infer any 
+% scanning parameters (such as phase encoding directions) of the corresponding sequence.
 
 fmap_json_name = fullfile(root_dir,project_label,[ 'sub-' sub_label ],...
     ['ses-' ses_label],...
@@ -128,18 +152,24 @@ fmap_json_name = fullfile(root_dir,project_label,[ 'sub-' sub_label ],...
     '_dir-' dir_label ...
     '_run-' run_label '_epi.json']);
 
-fmap_json.PhaseEncodingDirection = ''; % This technique combines two or more Spin Echo EPI scans with different phase encoding directions. In such a case, the phase encoding direction is specified in the corresponding JSON file as one of: ?i?, ?j?, ?k?, ?i-?, ?j-, ?k-?
-fmap_json.TotalReadoutTime = ''; % For these differentially phase encoded sequences, one also needs to specify the Total Readout Time defined as the time (in seconds) from the center of the first echo to the center of the last echo
-fmap_json.IntendedFor = ''; % Fieldmap data are linked to a specific scan(s) it was acquired for by filling the IntendedFor field. The IntendedFor field may contain one or more filenames with paths relative to the subject subfolder. The pathneeds to use forward slashes instead of backward slashes.
+fmap_json.PhaseEncodingDirection = ''; % This technique combines two or more 
+% Spin Echo EPI scans with different phase encoding directions. In such a case, 
+% the phase encoding direction is specified in the corresponding JSON file as 
+% one of: i, j, k, i-, j-, k-
+fmap_json.TotalReadoutTime = ''; % For these differentially phase encoded 
+% sequences, one also needs to specify the Total Readout Time defined as 
+% the time (in seconds) from the center of the first echo to the center 
+% of the last echo
+fmap_json.IntendedFor = ''; % Fieldmap data are linked to a specific scan(s) 
+% it was acquired for by filling the IntendedFor field. The IntendedFor field 
+% may contain one or more filenames with paths relative to the subject subfolder. 
+% The pathneeds to use forward slashes instead of backward slashes.
 
+
+json_options.indent = '    '; % this just makes the json file look prettier 
+% when opened in a text editor
 jsonSaveDir = fileparts(fmap_json_name);
 if ~isdir(jsonSaveDir)
-    fprintf('Warning: directory to save json file does not exist: %s \n',jsonSaveDir)
+    fprintf('Warning: directory to save json file does not exist, create: %s \n',jsonSaveDir)
 end
-json_options.indent = '    '; % this just makes the json file look prettier when opened in a text editor
-
 jsonwrite(fmap_json_name,fmap_json,json_options)
-
-
-
-

--- a/matlabCode/createBIDS_ieeg_channels_tsv.m
+++ b/matlabCode/createBIDS_ieeg_channels_tsv.m
@@ -1,11 +1,12 @@
 %% Template Matlab script to create an BIDS compatible electrodes.tsv file
 % This example lists all required and optional fields.
-% When adding additional metadata please use camelcase
+% When adding additional metadata please use CamelCase 
 %
 % DHermes, 2017
+% modified RG 201809
 
 %%
-clear all
+clear
 root_dir = '../';
 project_label = 'templates';
 ieeg_sub = '01';
@@ -21,31 +22,55 @@ channels_tsv_name = fullfile(root_dir,project_label,...
     '_run-' ieeg_run '_channels.tsv']);
 
 
+
 %% make a participants table and save 
 
-% required columns
-name = {''}; % Label of the channel, only contains letters and numbers. The label must correspond to _electrodes.tsv name and all ieeg type channels are required to have a position. In case of bipolar recordings where the channels are plugged into the hardware in bipolar manner, the channel name must be ?Name01-Name02? with a dash between the two electrode names.  (required).
-type = {''}; % Type of channel, see below for adequate keywords in this field (required), e.g. SEEG, ECOG. 
-units = {''}; % Physical unit of the value represented in this channel, e.g. V for Volt, specified according to the SI unit symbol and possibly prefix (e.g. milliV, microV), see BIDS spec for Units and Prefixes  (required).
-sampling_frequency = [0];% Sampling rate of the channel in Hz (required).
-low_cutoff = [0]; %Frequencies used for the low pass filter applied to the channel in Hz. If no low pass filter was applied, use n/a. Note that anti-alias is a low pass filter, specify its frequencies here if applicable (required).
-high_cutoff = [0]; % Frequencies used for the high pass filter applied to the channel in Hz. If no high pass filter applied, use n/a (required).
-notch = [0]; % Frequencies used for the notch filter applied to the channel, in Hz. If no notch filter applied, use n/a (required). 
 
-% recommended columns:
+
+%% required columns
+name = {''}; % Label of the channel, only contains letters and numbers. 
+% The label must correspond to _electrodes.tsv name and all ieeg type channels 
+% are required to have a position. In case of bipolar recordings where the 
+% channels are plugged into the hardware in bipolar manner, the channel name 
+% must be ?Name01-Name02? with a dash between the two electrode names.
+
+type = {''}; % Type of channel, see below for adequate keywords in this field 
+% e.g. SEEG, ECOG. 
+
+units = {''}; % Physical unit of the value represented in this channel,
+% e.g. V for Volt, specified according to the SI unit symbol and possibly 
+% prefix (e.g. milliV, microV), see BIDS spec for Units and Prefixes.
+
+sampling_frequency = [0];% Sampling rate of the channel in Hz.
+
+low_cutoff = [0]; %Frequencies used for the low pass filter applied to the 
+% channel in Hz. If no low pass filter was applied, use n/a. Note that 
+% anti-alias is a low pass filter, specify its frequencies here if applicable.
+
+high_cutoff = [0]; % Frequencies used for the high pass filter applied to 
+% the channel in Hz. If no high pass filter applied, use n/a.
+
+notch = [0]; % Frequencies used for the notch filter applied to the channel, 
+% in Hz. If no notch filter applied, use n/a (required). 
+
+
+
+%% recommended columns:
 group = {''}; % Which group of channels (grid/strip/probe) this channel belongs to. One group has one wire and noise can be shared. This can be a name or number (recommended).
 reference = {''}; % Specification of the reference (options: ?bipolar?, ?mastoid?, ?intracranial?, ?ElectrodeName01?) (recommended).
 
-% optional  columns
+
+
+%% optional  columns
 description = {''}; % Brief free-text description of the channel, or other information of interest (e.g. position (e.g., ?left lateral temporal surface?, ?unipolar/bipolar?, etc.). 
 status = {''}; %: Has good or bad: good channels can be taken into analysis. Bad indicates that the channel does not measure physiology: it is excessively noisy or broken or sitting on top of another grid, throughout the whole recording. More subtle descriptions should go in status_description.
 status_description = {''}; % Freeform text to specify subtle noise, or why a channel is bad.
 software_filters = {''}; % Optional field in case additional software filters were used.
 
+
+
+%% write
 t = table(name,type,units,sampling_frequency,low_cutoff,high_cutoff,...
     notch,group,reference,description,status,status_description,software_filters);
 
 writetable(t,channels_tsv_name,'FileType','text','Delimiter','\t');
-
-clear size
-

--- a/matlabCode/createBIDS_ieeg_coordsystem_json.m
+++ b/matlabCode/createBIDS_ieeg_coordsystem_json.m
@@ -1,12 +1,13 @@
 %% Template Matlab script to create an BIDS compatible _electrodes.json file
 % For BIDS-iEEG
 % This example lists all required and optional fields.
-% When adding additional metadata please use camelcase
+% When adding additional metadata please use CamelCase 
 %
 % DHermes, 2017
+% modified RG 201809
 
 %%
-
+clear
 root_dir = '../';
 ieeg_project = 'templates';
 ieeg_sub = '01';
@@ -18,23 +19,59 @@ electrodes_json_name = fullfile(root_dir,ieeg_project,...
     '_ses-' ieeg_ses ...
     '_coordsystem.json']);
 
-%%
-% Required fields:
-loc_json.iEEGCoordinateSystem  = '';% This refers to the coordinate space to which the iEEG electrodes xyz positions are to be interpreted, specified in the BEP003: Common derivatives (e.g. T1w, Talairach, MNI152NLin6Sym, fsaverage6_sym)
-loc_json.iEEGCoordinateUnits  = '';% This refers to how the coordinates of the iEEG channel positions are to be interpreted (e.g. ?mri?, ?ct?, "freesurfer_ras", ?Talairach?, "spm_mni" )
-loc_json.iEEGCoordinateProcessingDescripton = ''; % This refers to whether any projection has been done on the electrode positions (e.g. ?surface_projection_Hermes?,  ?surface_projection_Dykstra?,  ?none?, "spm_normalize_mni" )
-loc_json.IndendedFor = ''; % Relative path to the anatomical MRI to be used with the iEEG recording (e.g. "sub-<label>/ses-<label>/anat/sub-01_T1w.nii.gz")
-loc_json.AssociatedImageCoordinateSystem = '';% Coordinate system used to represent the coordinate system of the AssociatedImage. For an MRI/surface this can be (?native-acpc?, ?freesurfer_ras?, ?Talairach-Tournoux?, if a specific atlas is used, see MEG-BIDS Appendix 7 for preferred coordinate systems). For an operative photo this should always be ?indices? (required).
-loc_json.AssociatedImageCoordinateUnits = '';% MRI coordinate system used to represent the coordinates that are  listed in the other fields in this file, according to the software used (e.g. ?ctf?, "brainstorm_mri", "brainvisa_mri", "freesurfer_ras", "mni" or "other").  If "other" use the CoordinateSystemDescription field for more details. See 3.3.3. Fiducials information for more details.
-% Optional fields:
-loc_json.AssociatedImageCoordinateSystemDescription = ''; % Freeform description of the coordinate system. May also include a link to a documentation page or paper describing the system in greater detail.  See 3.3.3. Fiducials information for more details.
-loc_json.iEEGCoordinateProcessingReference = ''; % If processing has been done, this field can be used to describe the reference to a paper or program. (e.g. ?Hermes et al., 2010 JNeuroMeth?,  ?Dykstra et al., 2012 NeuroImage?,  ?Curry? ).
 
+
+%%  Required fields
+
+loc_json.iEEGCoordinateSystem  = '';% This refers to the coordinate space to 
+% which the iEEG electrodes xyz positions are to be interpreted, specified in 
+% the BEP003: Common derivatives (e.g. T1w, Talairach, MNI152NLin6Sym, fsaverage6_sym)
+
+loc_json.iEEGCoordinateUnits  = '';% This refers to how the coordinates of 
+% the iEEG channel positions are to be interpreted (e.g. ?mri?, ?ct?, "freesurfer_ras", 
+% ?Talairach?, "spm_mni" )
+
+loc_json.iEEGCoordinateProcessingDescripton = ''; % This refers to whether 
+% any projection has been done on the electrode positions (e.g. ?surface_projection_Hermes?,  
+% ?surface_projection_Dykstra?,  ?none?, "spm_normalize_mni" )
+
+loc_json.IndendedFor = ''; % Relative path to the anatomical MRI to be used 
+% with the iEEG recording (e.g. "sub-<label>/ses-<label>/anat/sub-01_T1w.nii.gz")
+
+loc_json.AssociatedImageCoordinateSystem = '';% Coordinate system used to 
+% represent the coordinate system of the AssociatedImage. For an MRI/surface 
+% this can be (?native-acpc?, ?freesurfer_ras?, ?Talairach-Tournoux?, if a 
+% specific atlas is used, see MEG-BIDS Appendix 7 for preferred coordinate 
+% systems). For an operative photo this should always be ?indices? (required).
+
+loc_json.AssociatedImageCoordinateUnits = '';% MRI coordinate system used to 
+% represent the coordinates that are  listed in the other fields in this file, 
+% according to the software used (e.g. ?ctf?, "brainstorm_mri", "brainvisa_mri", 
+% "freesurfer_ras", "mni" or "other").  If "other" use the CoordinateSystemDescription 
+% field for more details. See 3.3.3. Fiducials information for more details.
+
+
+
+%% Optional fields
+
+loc_json.AssociatedImageCoordinateSystemDescription = ''; % Freeform description 
+% of the coordinate system. May also include a link to a documentation page 
+% or paper describing the system in greater detail.  See 3.3.3. Fiducials 
+% information for more details.
+
+loc_json.iEEGCoordinateProcessingReference = ''; % If processing has been done, 
+% this field can be used to describe the reference to a paper or program. 
+% (e.g. ?Hermes et al., 2010 JNeuroMeth?,  ?Dykstra et al., 2012 NeuroImage?,  ?Curry? ).
+
+
+
+%% Write
 jsonSaveDir = fileparts(electrodes_json_name);
 if ~isdir(jsonSaveDir)
     fprintf('Warning: directory to save json file does not exist, create: %s \n',jsonSaveDir)
 end
 
-json_options.indent = '    '; % this just makes the json file look prettier when opened in a text editor
+json_options.indent = '    '; % this just makes the json file look prettier 
+% when opened in a text editor
 jsonwrite(electrodes_json_name,loc_json,json_options)
 

--- a/matlabCode/createBIDS_ieeg_electrodes_tsv.m
+++ b/matlabCode/createBIDS_ieeg_electrodes_tsv.m
@@ -31,7 +31,7 @@ name = {''}; % Name of the electrode
 x = [0]';
 y = [0]';
 z = [0]';
-size = [0]'; % Diameter in mm 
+Size = [0]'; % Diameter in mm 
 type = [0]'; % Type of intracranial electrode, one of [?surface?,  ?depth? , ?dbs?] 
 
 
@@ -55,3 +55,5 @@ grid_size = {''}; % Optional field to specify the dimensions of the grid the
 t = table(name,x,y,z,size,type,material,tissue,manufacturer,grid_size);
 
 writetable(t,electrodes_tsv_name,'FileType','text','Delimiter','\t');
+
+clear Size

--- a/matlabCode/createBIDS_ieeg_electrodes_tsv.m
+++ b/matlabCode/createBIDS_ieeg_electrodes_tsv.m
@@ -1,11 +1,13 @@
 %% Template Matlab script to create an BIDS compatible electrodes.tsv file
 % This example lists all required and optional fields.
-% When adding additional metadata please use camelcase
+% When adding additional metadata please use CamelCase 
 %
 % DHermes, 2017
+% modified RG 201809
+
 
 %%
-clear all
+clear
 root_dir = '../';
 project_label = 'templates';
 ieeg_sub = '01';
@@ -18,9 +20,13 @@ electrodes_tsv_name = fullfile(root_dir,project_label,...
     '_electrodes.tsv']);
 
 
+
 %% make a participants table and save 
 
-% required columns
+
+
+%% required columns
+
 name = {''}; % Name of the electrode
 x = [0]';
 y = [0]';
@@ -28,15 +34,24 @@ z = [0]';
 size = [0]'; % Diameter in mm 
 type = [0]'; % Type of intracranial electrode, one of [?surface?,  ?depth? , ?dbs?] 
 
-% optional columns:
-material = {''}; % Material of the electrodes
-tissue = {''}; % If a clinician has made an observation about the tissue underneath the electrode  (e.g. epilepsy, tumor, if nothing state n/a)
-manufacturer = {''}; % Optional field to specify the electrode manufacturer for each electrode. Can be used if electrodes were manufactured by more than one company.
-grid_size = {''}; % Optional field to specify the dimensions of the grid the electrode is a part of. Should be of the form `(M, N)`. E.g., (8, 8) or(1, 4).
 
+
+%% optional columns
+
+material = {''}; % Material of the electrodes
+
+tissue = {''}; % If a clinician has made an observation about the tissue 
+% underneath the electrode  (e.g. epilepsy, tumor, if nothing state n/a)
+
+manufacturer = {''}; % Optional field to specify the electrode manufacturer 
+% for each electrode. Can be used if electrodes were manufactured by more than one company.
+
+grid_size = {''}; % Optional field to specify the dimensions of the grid the 
+% electrode is a part of. Should be of the form `(M, N)`. E.g., (8, 8) or(1, 4).
+
+
+
+%% write
 t = table(name,x,y,z,size,type,material,tissue,manufacturer,grid_size);
 
 writetable(t,electrodes_tsv_name,'FileType','text','Delimiter','\t');
-
-clear size
-

--- a/matlabCode/createBIDS_ieeg_json.m
+++ b/matlabCode/createBIDS_ieeg_json.m
@@ -1,11 +1,13 @@
 %% Template Matlab script to create an BIDS compatible _ieeg.json file
 % This example lists all required and optional fields.
-% When adding additional metadata please use camelcase
+% When adding additional metadata please use CamelCase
 %
 % DHermes, 2017
+% modified RG 201809
+
 %%
 
-clear all
+clear 
 
 root_dir = '../';
 ieeg_project = 'templates';
@@ -24,55 +26,132 @@ ieeg_json_name = fullfile(root_dir,ieeg_project,[ 'sub-' ieeg_sub ],...
     '_task-' ieeg_task ...
     '_run-' ieeg_run '_ieeg.json']);
 
-%%
 
-% General fields, shared with MRI BIDS and MEG BIDS:
-% Required fields:
-ieeg_json.TaskName = ''; % Name of the task (for resting state use the ?rest? prefix). No two tasks should have the same name. Task label is derived from this field by removing all non alphanumeric ([a-zA-Z0-9]) characters. 
+
+%% General fields, shared with MRI BIDS and MEG BIDS:
+
+
+
+%% Required fields:
+ieeg_json.TaskName = ''; % Name of the task (for resting state use the rest
+% prefix). No two tasks should have the same name. Task label is derived 
+% from this field by removing all non alphanumeric ([a-zA-Z0-9]) characters. 
+
 ieeg_json.Manufacturer = ''; % Manufacturer of the amplifier system  (e.g. "TDT, blackrock")
-% Optional fields:
-ieeg_json.ManufacturersModelName = ''; % Manufacturer?s designation of the iEEG amplifier model (e.g. "TDT"). 
+
+
+
+%% Optional fields:
+
+ieeg_json.ManufacturersModelName = ''; % Manufacturer's designation of the 
+%iEEG amplifier model (e.g. "TDT"). 
+
 ieeg_json.TaskDescription = ''; % Longer description of the task.
-ieeg_json.Instructions = ''; % Text of the instructions given to participants before the recording. This is especially important in context of resting state and distinguishing between eyes open and eyes closed paradigms. 
+
+ieeg_json.Instructions = ''; % Text of the instructions given to participants 
+% before the recording. This is especially important in context of resting 
+% state and distinguishing between eyes open and eyes closed paradigms. 
+
 ieeg_json.CogAtlasID = ''; % URL of the corresponding Cognitive Atlas Task term
+
 ieeg_json.CogPOID = ''; %  URL of the corresponding CogPO term
-ieeg_json.InstitutionName = ''; %  The name of the institution in charge of the equipment that produced the composite instances. 
-ieeg_json.InstitutionAddress = ''; % The address of the institution in charge of the equipment that produced the composite instances. 
-ieeg_json.DeviceSerialNumber = ''; % The serial number of the equipment that produced the composite instances. A pseudonym can also be used to prevent the equipment from being identifiable, as long as each pseudonym is unique within the dataset.
 
-% General fields, shared with MEG BIDS:
-% Required fields:
-ieeg_json.EEGChannelCount = ''; % Number of EEG channels included in the recording (e.g. 0)  
+ieeg_json.InstitutionName = ''; %  The name of the institution in charge of 
+% the equipment that produced the composite instances.
+
+ieeg_json.InstitutionAddress = ''; % The address of the institution in charge 
+% of the equipment that produced the composite instances. 
+
+ieeg_json.DeviceSerialNumber = ''; % The serial number of the equipment that 
+% produced the composite instances. A pseudonym can also be used to prevent 
+% the equipment from being identifiable, as long as each pseudonym is unique 
+% within the dataset.
+
+
+
+%% General fields, shared with MEG BIDS:
+
+
+
+%%  Required fields:
+
+ieeg_json.EEGChannelCount = ''; % Number of EEG channels included in the recording (e.g. 0) 
+
 ieeg_json.EOGChannelCount = ''; % Number of EOG channels included in the recording (e.g. 1)
+
 ieeg_json.ECGChannelCount = ''; % Number of ECG channels included in the recording (e.g. 1)
+
 ieeg_json.EMGChannelCount = ''; % Number of EMG channels included in the recording (e.g. 1)
-ieeg_json.MiscChannelCount = ''; % Number of miscellaneous channels included in the recording (e.g. 1)
-ieeg_json.TriggerChannelCount = ''; % Number of channels for digital (TTL bit level) triggers (e.g. 0) 
-ieeg_json.PowerLineFrequency = ''; % Frequency (in Hz) of the power grid where the iEEG recording was done (i.e. 50 or 60) 
-% Optional fields:
+
+ieeg_json.MiscChannelCount = ''; % Number of miscellaneous channels included in 
+% the recording (e.g. 1)
+
+ieeg_json.TriggerChannelCount = ''; % Number of channels for digital (TTL bit level) 
+% triggers (e.g. 0) 
+
+ieeg_json.PowerLineFrequency = ''; % Frequency (in Hz) of the power grid where 
+% the iEEG recording was done (i.e. 50 or 60) 
+
+
+
+%% Optional fields:
 ieeg_json.RecordingDuration = ''; % Length of the recording in seconds (e.g. 3600)
-ieeg_json.RecordingType = ''; %  ?continuous?, ?epoched? 
-ieeg_json.EpochLength = ''; % Duration of individual epochs in seconds (e.g. 1). If recording was continuous, set value to ?Inf?.
-ieeg_json.DeviceSoftwareVersion = ''; % Manufacturer?s designation of the acquisition software.
-ieeg_json.SubjectArtefactDescription = ''; % Freeform description of the observed subject artefact and its possible cause (e.g. ?door open?, ?nurse walked into room at 2 min?, "Vagus Nerve Stimulator", ?non-removable implant?, ?seizure at 10 min?). If this field is left empty, it will be interpreted as absence of artifacts.
 
-% Specific iEEG fields:
-% Required fields:
-ieeg_json.iEEGSurfChannelCount = ''; % Number of iEEG surface channels included in the recording (e.g. 120) 
-ieeg_json.iEEGDepthChannelCount = ''; % Number of iEEG depth channels included in the recording (e.g. 8) 
-% Optional fields:
-ieeg_json.iEEGPlacementScheme = ''; % General description of the placement of the iEEG electrodes. Left/right/bilateral/depth/surface (e.g. ?left frontal grid and bilateral hippocampal depth? or ?surface strip and STN depth?).
-ieeg_json.iEEGReferenceScheme = ''; % Specify reference scheme if more complex than one channel or CAR.
-ieeg_json.Stimulation = ''; % Optional field to specify if electrical stimulation was done during the recording (options are 1 for yes, 0 for no). Parameters for event-like stimulation should be specified in the _events.tsv file (see example underneath). Continuous parameters that change across ?scans? can be indicated in the the _scans.tsv file.
-ieeg_json.Medication = ''; %  Optional field to add medication that the patient was on during a recording. 
+ieeg_json.RecordingType = ''; % continuous, epoched 
 
+ieeg_json.EpochLength = ''; % Duration of individual epochs in seconds (e.g. 1).
+% If recording was continuous, set value to Inf.
+
+ieeg_json.DeviceSoftwareVersion = ''; % Manufacturer's designation of the acquisition software.
+
+ieeg_json.SubjectArtefactDescription = ''; % Freeform description of the observed 
+% subject artefact and its possible cause (e.g. door open, nurse walked into room at 2 min, 
+% "Vagus Nerve Stimulator", non-removable implant, seizure at 10 min). 
+% If this field is left empty, it will be interpreted as absence of artifacts.
+
+
+
+%% Specific iEEG fields:
+
+
+
+%% Required fields:
+ieeg_json.iEEGSurfChannelCount = ''; % Number of iEEG surface channels included 
+% in the recording (e.g. 120) 
+
+ieeg_json.iEEGDepthChannelCount = ''; % Number of iEEG depth channels included 
+% in the recording (e.g. 8) 
+
+
+
+%% Optional fields:
+
+ieeg_json.iEEGPlacementScheme = ''; % General description of the placement 
+% of the iEEG electrodes. Left/right/bilateral/depth/surface 
+% (e.g. ?left frontal grid and bilateral hippocampal depth? or ?surface strip 
+% and STN depth?).
+
+ieeg_json.iEEGReferenceScheme = ''; % Specify reference scheme if more complex 
+% than one channel or CAR.
+
+ieeg_json.Stimulation = ''; % Optional field to specify if electrical stimulation 
+% was done during the recording (options are 1 for yes, 0 for no). Parameters 
+% for event-like stimulation should be specified in the _events.tsv file 
+% (see example underneath). Continuous parameters that change across ?scans? 
+% can be indicated in the the _scans.tsv file.
+
+ieeg_json.Medication = ''; %  Optional field to add medication that the patient 
+% was on during a recording. 
+
+
+
+%% write
 jsonSaveDir = fileparts(ieeg_json_name);
 if ~isdir(jsonSaveDir)
     fprintf('Warning: directory to save json file does not exist, create: %s \n',jsonSaveDir)
 end
 
-json_options.indent = '    '; % this just makes the json file look prettier when opened in a text editor
+json_options.indent = '    '; % this just makes the json file look prettier 
+% when opened in a text editor
+
 jsonwrite(ieeg_json_name,ieeg_json,json_options)
-
-
-

--- a/matlabCode/createBIDS_participants_tsv.m
+++ b/matlabCode/createBIDS_participants_tsv.m
@@ -1,11 +1,12 @@
 %% Template Matlab script to create an BIDS compatible participants.tsv file
 % This example lists all required and optional fields.
-% When adding additional metadata please use camelcase
+% When adding additional metadata please use CamelCase
 %
 % DHermes, 2017
+% modified RG 201809
 
 %%
-clear all
+clear
 root_dir = '../';
 project_label = 'templates';
 
@@ -14,7 +15,7 @@ participants_tsv_name = fullfile(root_dir,project_label,...
 
 %% make a participants table and save 
 
-participant_id = {'sub-01'}; % onsets in seconds
+participant_id = {'sub-01'};
 age = [0]';
 sex = {'m'}; 
 


### PR DESCRIPTION
Hey

- I have done a bit of comment cleaning in some files.
- I also realized that some new or required fields were missing in the scripts for BOLD (e.g recent additions for sparse sequences). I hopeI I have not forgotten anything.
- Also I removed some fields for the for the scripts for T1w (some fields I think applied only to functional stuff: when refering to field maps). Was I right in doing that?
- Also technically for completeness we would required a full version for fieldmaps jsons to include all the fields that are recommended for all sequences but I have not created it.

Hope this helps.