### PR TITLE
add basic file templates at root level

### DIFF
--- a/templates/README
+++ b/templates/README
@@ -1,0 +1,1 @@
+This contains some basic description about the BIDS dataset.

--- a/templates/participants.json
+++ b/templates/participants.json
@@ -1,0 +1,24 @@
+{
+    "age": {
+        "LongName": "age",
+        "Description": "age of the participant",
+        "Units": "years"
+    },
+    "handedness": {
+        "LongName": "handedness",
+        "Description": "handedness of the participant as reported by the participant",
+        "Levels": {
+            "l": "left",
+            "r": "right"
+        }
+    },
+    "sex": {
+        "LongName": "sex",
+        "Description": "sex of the participant",
+        "Levels": {
+            "m": "male",
+            "f": "female"
+        }
+    }
+}
+

--- a/templates/participants.tsv
+++ b/templates/participants.tsv
@@ -1,2 +1,2 @@
-participant_id	age	sex
-sub-01	0	m
+participant_id	age	handedness	sex
+sub-01	18	r	m


### PR DESCRIPTION
This is making the existing `participants.tsv` complete by providing a fitting dictionary that contains descriptions of the keys used in there.

I also added a README, which is a classic file to be found at the root of the BIDS dataset.